### PR TITLE
"destr" is now default for JSON deserialization

### DIFF
--- a/.changeset/big-maps-march.md
+++ b/.changeset/big-maps-march.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc": minor
+---
+
+The default JSON parser is now unjs/destr

--- a/docs/text/limitations.mdx
+++ b/docs/text/limitations.mdx
@@ -150,6 +150,10 @@ additional types may require a separate serialization library or manual work to 
 
 ### Default JSON Serialization
 
+By default, Prim+RPC uses the native `JSON` object for serializing JSON and
+[unjs/destr](https://github.com/unjs/destr#readme) for parsing JSON (which mostly behaves similar to `JSON` but also
+avoids prototype pollution). This is considered the default JSON handler.
+
 Since Prim+RPC messages are JSON, the default JSON handler is used with special handling of callbacks, files, and Error
 objects. However, this is subject to the limitations of the default JSON handler. This means that other types of data
 will need to be serialized to a string and will not automatically convert back to the same type on the server. If the

--- a/libs/rpc/package.json
+++ b/libs/rpc/package.json
@@ -38,6 +38,7 @@
 	},
 	"dependencies": {
 		"defu": "^6.1.2",
+		"destr": "^2.0.0",
 		"just-remove": "^3.2.0",
 		"just-safe-get": "^4.2.0",
 		"mitt": "^3.0.0",

--- a/libs/rpc/src/options.ts
+++ b/libs/rpc/src/options.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { defu } from "defu"
+import { destr } from "destr"
 import { PrimOptions, PrimServerOptions, RpcCall } from "./interfaces"
 
 /**
@@ -33,7 +34,7 @@ const createBaseClientOptions = (server = false): PrimOptions => ({
 	clientBatchTime: 0,
 	// allow options of using a different JSON parsing/conversion library (for instance, "superjson")
 	// NOTE: JSON properties are not enumerable so create an object with enumerable properties referencing JSON methods
-	jsonHandler: { stringify: JSON.stringify, parse: JSON.parse },
+	jsonHandler: { stringify: JSON.stringify, parse: destr },
 	// `client()` is intended to be overridden so as not to force any one HTTP framework but default is fine for most cases
 	// eslint-disable-next-line @typescript-eslint/require-await
 	methodPlugin: async (_endpoint, jsonBody) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,6 +392,9 @@ importers:
       defu:
         specifier: ^6.1.2
         version: 6.1.2
+      destr:
+        specifier: ^2.0.0
+        version: 2.0.0
       just-remove:
         specifier: ^3.2.0
         version: 3.2.0
@@ -4421,6 +4424,10 @@ packages:
   /destr@1.2.2:
     resolution: {integrity: sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==}
     dev: true
+
+  /destr@2.0.0:
+    resolution: {integrity: sha512-FJ9RDpf3GicEBvzI3jxc2XhHzbqD8p4ANw/1kPsFBfTvP1b7Gn/Lg1vO7R9J4IVgoMbyUmFrFGZafJ1hPZpvlg==}
+    dev: false
 
   /destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}


### PR DESCRIPTION
Previously, the built-in JSON object was used for deserialization. To help avoid the potential for prototype pollution, the default `.parse()` method is now provided from [unjs/destr](https://github.com/unjs/destr) which includes removal of special keys by default.

This does come with a performance hit (in common scenarios) but could prevent some unsafe usages and should be enabled by default. This behavior can always be overridden if needed, like so:

```typescript
// new JSON handler
import { destr } from "destr"
const oldJsonHandler = { stringify: JSON.stringify, parse: destr }
// old JSON handler
const jsonHandler = { stringify: JSON.stringify, parse: JSON.parse }
// overriding the default on both server/client:
createPrimServer({ jsonHandler })
createPrimClient({ jsonHandler })
``` 