### PR TITLE
Security Guide and Additional Options

### DIFF
--- a/.changeset/clever-rivers-teach.md
+++ b/.changeset/clever-rivers-teach.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc-plugins": patch
+---
+
+Next.js handler renamed defineNextjsAppHandler -> defineNextjsAppPrimHandler

--- a/.changeset/lazy-laws-remember.md
+++ b/.changeset/lazy-laws-remember.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc-plugins": minor
+---
+
+Next.js now uses File object, no longer uses tmp directory

--- a/.changeset/nervous-impalas-sin.md
+++ b/.changeset/nervous-impalas-sin.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc-plugins": minor
+---
+
+H3 integration now uses File object, no longer saves file to tmp directory

--- a/.changeset/violet-balloons-fetch.md
+++ b/.changeset/violet-balloons-fetch.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc-plugins": minor
+---
+
+Fastify plugin now saves to File object, no longer saves to tmp directory

--- a/.changeset/wild-kids-applaud.md
+++ b/.changeset/wild-kids-applaud.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc-plugins": minor
+---
+
+Express integration now uses File object, no longer uses tmp directory

--- a/apps/frontend/src/app/prim/[[...prim]]/route.ts
+++ b/apps/frontend/src/app/prim/[[...prim]]/route.ts
@@ -1,11 +1,11 @@
 import { createPrimServer } from "@doseofted/prim-rpc"
-import { defineNextjsAppHandler } from "@doseofted/prim-rpc-plugins/nextjs"
+import { defineNextjsAppPrimHandler } from "@doseofted/prim-rpc-plugins/nextjs"
 import * as moduleAll from "@doseofted/prim-example"
 import jsonHandler from "superjson"
 
 const module = process.env.NODE_ENV === "development" ? moduleAll : { greetings: moduleAll.greetings }
 const prim = createPrimServer({ module, jsonHandler })
-export const { GET, POST } = defineNextjsAppHandler({
+export const { GET, POST } = defineNextjsAppPrimHandler({
 	prim,
 	headers: {
 		"Access-Control-Allow-Origin": "*",

--- a/apps/frontend/src/components/DocsToc.tsx
+++ b/apps/frontend/src/components/DocsToc.tsx
@@ -11,9 +11,9 @@ export function DocsTableOfContents(props: Props) {
 			name: "Getting Started",
 			sections: [
 				{ name: "Introduction", link: "/" },
-				{ name: "Examples", link: "/examples" },
 				{ name: "Setup", link: "/setup" },
-				{ name: "Usage", link: "/usage" },
+				{ name: "Examples", link: "/examples" },
+				{ name: "Features", link: "/features" },
 				{ name: "Security", link: "/security" },
 				{ name: "Comparisons", link: "/comparisons" },
 				{ name: "Limitations", link: "/limitations" },

--- a/apps/frontend/src/pages/index.tsx
+++ b/apps/frontend/src/pages/index.tsx
@@ -299,7 +299,7 @@ export default function Home({ greeting }: Props) {
 							Try An Example
 						</Link>
 						<div className="w-full block lg:hidden" />
-						<Link href="/docs/usage" className="btn glass hover:bg-neutral text-white">
+						<Link href="/docs/features" className="btn glass hover:bg-neutral text-white">
 							<Icon className="w-6 h-6" icon="carbon:idea" />
 							Learn to Use
 						</Link>

--- a/docs/text/examples.mdx
+++ b/docs/text/examples.mdx
@@ -17,7 +17,7 @@ working with Prim+RPC.
 
 See the `README.md` files in each linked example for an overview. Each example is commented thoroughly to explain each
 step. If you only need to see examples of how to use certain features of Prim+RPC, you may also
-[read the Usage guide](/docs/usage).
+[read the Usage guide](/docs/features).
 
 ## Simple Test
 

--- a/docs/text/features.mdx
+++ b/docs/text/features.mdx
@@ -3,7 +3,7 @@
 import { LayoutDocs } from "@/components/LayoutDocs"
 import { Alert } from "@/components/Alert"
 export const meta = {
-	title: "Usage",
+	title: "Features and How to Use",
 }
 export default ({ children }) => <LayoutDocs meta={meta}>{children}</LayoutDocs>
 
@@ -244,7 +244,7 @@ uploadFile.rpc = true
 // ...client defined earlier
 
 const file = new File(["Hello from client!"], "hello.txt", { type: "text/plain" })
-await client.uploadFile(file) // server will log contents of file
+await client.uploadFile(file) // server will log file name and save to disk
 ```
 
 </CH.Code>

--- a/docs/text/index.mdx
+++ b/docs/text/index.mdx
@@ -130,7 +130,7 @@ like callback support and file upload handling, options that you can configure, 
 your own), serialization handlers for RPC that you can customize, documentation that you can generate, and more.
 
 You can [learn how to set up your own project](/docs/setup) or [see the available examples](/docs/examples) to get
-started! Once your project is set up you can then [learn how to use Prim+RPC](/docs/usage)!
+started! Once your project is set up you can then [learn how to use Prim+RPC](/docs/features)!
 
 ## Framework Goals
 

--- a/docs/text/plugins/server.mdx
+++ b/docs/text/plugins/server.mdx
@@ -58,9 +58,9 @@ You may also register the Hono middleware yourself by importing `honoPrimRpc` an
 
 ## Fastify
 
-| For                                           | Plugin Type    | Transport Type | File Support      |
-| --------------------------------------------- | -------------- | -------------- | ----------------- |
-| [Fastify](https://github.com/fastify/fastify) | Method handler | HTTP           | `Promise<string>` |
+| For                                           | Plugin Type    | Transport Type | File Support |
+| --------------------------------------------- | -------------- | -------------- | ------------ |
+| [Fastify](https://github.com/fastify/fastify) | Method handler | HTTP           | `File`       |
 
 You can configure Fastify with Prim+RPC like so (note that the multipart plugin is optional and used for uploading
 files):

--- a/docs/text/plugins/server.mdx
+++ b/docs/text/plugins/server.mdx
@@ -87,9 +87,9 @@ the function's `this` context.
 
 ## Express
 
-| For                                             | Plugin Type    | Transport Type | File Support      |
-| ----------------------------------------------- | -------------- | -------------- | ----------------- |
-| [Express](https://github.com/expressjs/express) | Method handler | HTTP           | `Promise<string>` |
+| For                                             | Plugin Type    | Transport Type | File Support |
+| ----------------------------------------------- | -------------- | -------------- | ------------ |
+| [Express](https://github.com/expressjs/express) | Method handler | HTTP           | `File`       |
 
 You can configure Express with Prim+RPC like so (note that the multipart plugin is optional and used for uploading
 files):

--- a/docs/text/plugins/server.mdx
+++ b/docs/text/plugins/server.mdx
@@ -16,17 +16,6 @@ method handler and one callback handler (see **Plugin Type** in tables below). R
 server you must also specify a [compatible _plugin_ on the client](/docs/plugins/client). For plugins/handlers to be
 compatible they must use the same type of transport (given in **Transport Type** in tables below).
 
-<Alert prose icon="carbon:information">
-
-File upload support is a work-in-progress. In the **File Support** column, you will find if a handler supports file
-uploads and, if so, what type is given to your defined functions.
-
-In the future, all file uploads may be given as `File` by default or the expected type suitable for the handler's
-environment. Some handlers today will return `Promise<string>` where the string is the file location in your operating
-system's temporary directory. This behavior will change and the current statuses are documented below.
-
-</Alert>
-
 ## Table of Contents
 
 ## Hono
@@ -192,9 +181,9 @@ const client = createPrimClient({
 
 ## Next.js
 
-| For                                           | Plugin Type    | Transport Type | File Support      |
-| --------------------------------------------- | -------------- | -------------- | ----------------- |
-| [Next.js](https://github.com/vercel/next.js/) | Method handler | HTTP           | `Promise<string>` |
+| For                                           | Plugin Type    | Transport Type | File Support |
+| --------------------------------------------- | -------------- | -------------- | ------------ |
+| [Next.js](https://github.com/vercel/next.js/) | Method handler | HTTP           | `File`       |
 
 Prim+RPC can be used with Next.js by defining a dedicated route. Currently, only the App Router is supported but Pages
 Router support is being considered. Next.js allows App/Page Routers to live in the same project.

--- a/docs/text/plugins/server.mdx
+++ b/docs/text/plugins/server.mdx
@@ -204,11 +204,11 @@ Next.js):
 
 ```typescript app/prim/[[...prim]]/route.ts
 import { createPrimServer } from "@doseofted/prim-rpc"
-import { defineNextjsAppHandler } from "@doseofted/prim-rpc-plugins/nextjs"
+import { defineNextjsAppPrimHandler } from "@doseofted/prim-rpc-plugins/nextjs"
 import module from "./my-example-module"
 
 const prim = createPrimServer({ module, prefix: "/prim" })
-export const { GET, POST } = defineNextjsAppHandler({ prim })
+export const { GET, POST } = defineNextjsAppPrimHandler({ prim })
 ```
 
 On the client-side, you can use the Prim+RPC client with a compatible method plugin. Since the client could be used

--- a/docs/text/plugins/server.mdx
+++ b/docs/text/plugins/server.mdx
@@ -139,9 +139,9 @@ the function's `this` context. The callback handler can be used with the method 
 
 ## Nuxt / Nitro / H3
 
-| For                                                                                                            | Plugin Type    | Transport Type | File Support      |
-| -------------------------------------------------------------------------------------------------------------- | -------------- | -------------- | ----------------- |
-| [Nuxt](https://github.com/nuxt/nuxt), [Nitro](https://github.com/unjs/nitro), [H3](https://github.com/unjs/h3) | Method handler | HTTP           | `Promise<string>` |
+| For                                                                                                            | Plugin Type    | Transport Type | File Support |
+| -------------------------------------------------------------------------------------------------------------- | -------------- | -------------- | ------------ |
+| [Nuxt](https://github.com/nuxt/nuxt), [Nitro](https://github.com/unjs/nitro), [H3](https://github.com/unjs/h3) | Method handler | HTTP           | `File`       |
 
 Prim+RPC can be used with H3 and frameworks built upon H3 such as Nitro and Nuxt 3. Setup steps vary depending on which
 framework you are using.
@@ -151,7 +151,7 @@ You can configure H3 with Prim+RPC like so:
 ```typescript
 import { createPrimServer } from "@doseofted/prim-rpc"
 import { createMethodHandler } from "@doseofted/prim-rpc-plugins/h3"
-import { createApp, eventHandler, toNodeListener } from "h3"
+import { createApp, toNodeListener } from "h3"
 import { createServer } from "node:http"
 import module from "./my-example-module"
 

--- a/docs/text/reference/configuration.mdx
+++ b/docs/text/reference/configuration.mdx
@@ -154,10 +154,12 @@ If a callback plugin is given, it's important to note that each plugin used on t
 | _`false`_ | _`JSON`_ | 🔴 Yes        |
 
 Functions used with Prim+RPC have to be serialized before sending a function call (RPC) to the server. By default, any
-RPC made with Prim+RPC will use the environment's default JSON handler.
+RPC made with Prim+RPC will use the environment's default JSON handler for serialization and
+[unjs/destr](https://github.com/unjs/destr) for deserialization (which provides the benefit of protection from prototype
+pollution while behaving predictably).
 
-This can be overridden by providing your own JSON handler. The given handler must follow the same/similar signature of
-the default JSON handler: namely, it needs to have `.parse()` and `.stringify()` methods.
+You can override the default JSON handler as you'd like. The given handler must follow the same/similar signature of the
+default JSON handler: namely, it needs to have `.parse()` and `.stringify()` methods.
 
 ```typescript
 import { createPrimClient } from "@doseofted/prim-rpc"
@@ -170,10 +172,21 @@ createPrimClient({
 ```
 
 This can be useful for parsing additional types. For example, [`superjson`](https://www.npmjs.com/package/superjson) is
-great for parsing additional JavaScript types, [`devalue`](https://www.npmjs.com/package/devalue) is useful for cyclical
-references, [`destr`](https://www.npmjs.com/package/destr) for someone security-minded. You could even use
-[`yaml`](https://www.npmjs.com/package/yaml) if readability is top priority. These are only examples and you can use any
-JSON handler or create your own.
+great for parsing additional JavaScript types. A library like [`devalue`](https://www.npmjs.com/package/devalue) is
+useful for cyclical references. You could even use [`yaml`](https://www.npmjs.com/package/yaml) if readability is top
+priority. These are only examples and you can use any JSON handler or create your own.
+
+You may also use the default JSON handler for your environment (foregoing safety provided by the default) by setting the
+JSON handler explictly, like so:
+
+```typescript
+import { createPrimClient } from "@doseofted/prim-rpc"
+
+createPrimClient({
+	// NOT RECOMMENDED: using unjs/destr for parsing is recommended (and the default)
+	jsonHandler: { stringify: JSON.stringify, parse: JSON.parse },
+})
+```
 
 <Alert icon="carbon:warning" type="alert-warning" prose>
 

--- a/docs/text/reference/configuration.mdx
+++ b/docs/text/reference/configuration.mdx
@@ -675,6 +675,20 @@ built-in methods, when using this option.
 
 </Alert>
 
+### `.showErrorStack`
+
+| Required  | Default   | Sync Required |
+| --------- | --------- | ------------- |
+| _`false`_ | _`false`_ | 🟢 No         |
+
+When using the [`.handleError`](#handleerror) option of Prim+RPC, errors thrown on the server are recreated on the
+client. This error may possibly include the call stack which generally shouldn't be sent to the client. By default, this
+property is removed from the error before sending an RPC response.
+
+In development, this stack trace can be useful for tracing an error so you may enable showing this stack when available
+by toggling this option to `true`. Care should be taken with this option to ensure that it is not enabled in a
+production environment.
+
 ## Testing
 
 Included in Prim+RPC are utilities for running local tests with Prim+RPC, intended to be used with tools like Vitest or

--- a/docs/text/reference/configuration.mdx
+++ b/docs/text/reference/configuration.mdx
@@ -393,6 +393,8 @@ const server = createPrimServer({
 	allowList: { sayHello: true },
 	// link[2:17] #methodsonmethods
 	methodsOnMethods: [],
+	// link[2:15] #showerrorstack
+	showErrorStack: false,
 })
 ```
 

--- a/docs/text/security.mdx
+++ b/docs/text/security.mdx
@@ -120,7 +120,30 @@ createPrimServer({ module: { submitForm } })
 ```
 
 Now when we submit this form, we will be presented an error because the client did not provide the boolean value that is
-expected.
+expected. If you're coming from tRPC, you may consider using Zod's syntax for defining a function (which bears some
+resemblance to defining a tRPC router):
+
+```typescript
+import { subscribeToNewsLetter } from "./my-newsletter-service"
+import { z } from "zod"
+
+// this is only a simple demonstration
+const submitForm = z
+	.function()
+	.args(
+		z.object({
+			email: z.string().trim().email(),
+			subscribe: z.boolean().default(false),
+		})
+	)
+	.returns(z.boolean())
+	.implements(form => {
+		return form.subscribe ? subscribeToNewsLetter(form.email) : false
+	})
+submitForm.rpc = true
+
+createPrimServer({ module: { submitForm } })
+```
 
 ## Consider the JSON Handler
 
@@ -134,9 +157,10 @@ issues and this should be considered, especially if RPC is intended to be shared
 
 ## Secure the Transport
 
-Prim+RPC keeps a narrow scope: it handles RPC but it utilizes plugins for transport. This means that you can choose any
-transport that you'd like by using an available plugin or creating your own but it means that the security of the
-transport falls outside of Prim+RPC's scope.
+Prim+RPC keeps a narrow scope: it handles RPC but it utilizes separate plugins for transport. This means that you can
+choose any transport that you'd like by using an available plugin or creating your own but it means that the security of
+the transport falls outside of Prim+RPC's scope.
 
-Securing the transport means something different for every environment. For instance, if you're using Prim+RPC on a web
-server then you may consider ...
+Securing the transport may mean something different depending on the environment. For instance, if you're using Prim+RPC
+on a web server then you may consider using TLS, CORS headers, rate limiting, authentication, and other means. On a web
+client, you may consider the possibility of XSS.

--- a/docs/text/security.mdx
+++ b/docs/text/security.mdx
@@ -14,7 +14,8 @@ export default ({ children }) => <LayoutDocs meta={meta}>{children}</LayoutDocs>
 
 <Alert prose icon="carbon:information">
 
-Prim+RPC does not have a stable release and should not yet be used in production applications.
+Prim+RPC does not have a stable release and should not yet be used in production applications. Please report any
+security issues that you find according to the [security policy](https://github.com/doseofted/prim-rpc/security/policy).
 
 </Alert>
 
@@ -23,32 +24,119 @@ incredibly easy to add new functions to the backend. However caution should be t
 cannot be trusted. Tasks such as validation, sanitation, authentication, and more are outside of Prim+RPC's
 responsibilities and are left to the developer (and the libraries that you choose).
 
-<Alert icon="carbon:warning" type="alert-warning">
-	Documentation in Progress
-</Alert>
-
 ## Table of Contents
 
-## Set RPC Property on Functions
+## Set Allowed Functions as RPC
 
-<Alert icon="carbon:warning" type="alert-warning">
-	Documentation in Progress
-</Alert>
+When you pass a function to the `.module` option of Prim+RPC, it is intended to become RPC. By default however you will
+be denied access to execute the function remotely on the client until you explicitly mark it as an RPC. This is done in
+one of two ways: by setting the `.rpc` property on the function to `true` or by adding your function to the `.allowList`
+option of the Prim+RPC server.
 
-## Use the Allow List
+```ts
+import { createPrimServer } from "@doseofted/prim-rpc"
 
-<Alert icon="carbon:warning" type="alert-warning">
-	Documentation in Progress
-</Alert>
+// This can be called from the client because we set the `.rpc` property to `true`
+function myPublicFunction() {
+	return "I'm allowed to be called from the client"
+}
+myPublicFunction.rpc = true
+
+// This cannot be called from the client even though we passed it to the client
+// (note: type definitions are still shared because is is given to server below)
+function myPrivateFunction() {
+	return "I'm only allowed to be called on the server"
+}
+
+// While we cannot add an `.rpc` property directly, we can add it to the allow list below
+// We could alternatively create a wrapper function with an `.rpc` property that calls `myFrozenFunction()`
+function myFrozenFunction() {
+	return "I'm allowed to be called from the client"
+}
+Object.freeze(myFrozenFunction)
+
+createPrimServer({
+	module: { myPublicFunction, myPrivateFunction, myFrozenFunction },
+	allowList: { myFrozenFunction: true },
+})
+```
 
 ## Don't Trust Arguments
 
-<Alert icon="carbon:warning" type="alert-warning">
-	Documentation in Progress
-</Alert>
+Prim+RPC does not validate or sanitize arguments passed to the server. It is up to the developer to ensure that the
+arguments provided are of the expected type and shape. You may choose a validation library of your choice to accomplish
+this. Without a validation library, it should be expected that types given from the client could not match your type
+definitions. Consider the following:
 
-## Override the JSON Handler
+<CH.Code>
 
-<Alert icon="carbon:warning" type="alert-warning">
-	Documentation in Progress
-</Alert>
+```typescript server.ts
+import { subscribeToNewsLetter } from "./my-newsletter-service"
+
+interface FormInputs {
+	email: string
+	subscribe: boolean
+}
+// this is only a simple demonstration
+function submitForm(form: FormInputs) {
+	return form.subscribe ? subscribeToNewsLetter(form.email) : false
+}
+submitForm.rpc = true
+
+createPrimServer({ module: { submitForm } })
+```
+
+---
+
+```typescript client.ts
+import { backend } from "./created-prim-client"
+// backend was given truthy value so the email will be subscribed without their consent
+await backend.submitForm({ email: "ted@example.com", subscribe: "no" })
+```
+
+</CH.Code>
+
+In this example a user is subscribed without their consent because the string `no` is a truthy value. This can be
+avoided with validation of given arguments. You may choose any library that you'd like to validate arguments. We'll use
+Zod in this example but you could also use libraries like TypeBox, ArkType, or many others. Below is a safer example:
+
+```typescript
+import { subscribeToNewsLetter } from "./my-newsletter-service"
+import { z } from "zod"
+
+const formInputsSchema = z.object({
+	email: z.string().trim().email(),
+	subscribe: z.boolean().default(false),
+})
+
+// this is only a simple demonstration
+export function submitForm(givenForm: z.infer<typeof formInputsSchema>) {
+	const form = formInputsSchema.parse(givenForm)
+	return form.subscribe ? subscribeToNewsLetter(form.email) : false
+}
+submitForm.rpc = true
+
+createPrimServer({ module: { submitForm } })
+```
+
+Now when we submit this form, we will be presented an error because the client did not provide the boolean value that is
+expected.
+
+## Consider the JSON Handler
+
+By default, Prim+RPC will use the environment's default JSON handler for serialization and
+[unjs/destr](https://github.com/unjs/destr) for deserialization (which provides the benefit of protection from prototype
+pollution while behaving predictably).
+
+You may override the JSON handler with your own as you'd like. This may provide support for additional types or may even
+be used to serialize to a format other than JSON. However be aware that a new handler could introduce new security
+issues and this should be considered, especially if RPC is intended to be shared over public channels.
+
+## Secure the Transport
+
+Prim+RPC keeps a narrow scope: it handles RPC but it utilizes plugins for transport. This means that you can choose any
+transport that you'd like by using an available plugin or creating your own but it means that the security of the
+transport falls outside of Prim+RPC's scope.
+
+Securing the transport means something different for every environment. For instance, if you're using Prim+RPC on a web
+server then you may consider ...

--- a/docs/text/setup.mdx
+++ b/docs/text/setup.mdx
@@ -31,7 +31,7 @@ this guide how to do that! The command below will download the example project o
 npx giget@latest gh:doseofted/prim-rpc-examples/starter prim-rpc-examples/starter
 ```
 
-Once you've finished this guide and set up your project, you can [learn how to write functions](/docs/usage) to be
+Once you've finished this guide and set up your project, you can [learn how to write functions](/docs/features) to be
 shared as Prim+RPC.
 
 ## Table of Contents
@@ -395,7 +395,7 @@ There's one more optional step that you can complete. If you'd like to support c
 server, you'll need to set up a callback handler on the server and a callback plugin on the client. If you don't use
 callback then this isn't necessary. If you would like to set this up, follow along in the next step!
 
-Otherwise, you're now ready to [learn how to further use Prim+RPC](/docs/usage). You can also customize the Prim+RPC
+Otherwise, you're now ready to [learn how to further use Prim+RPC](/docs/features). You can also customize the Prim+RPC
 client and server by following the [configuration reference](/docs/reference/configuration).
 
 ## Use Callbacks
@@ -549,5 +549,5 @@ prim.typeMessage(result, letter => {
 })
 ```
 
-You're now ready to [learn how to further use Prim+RPC](/docs/usage). You can also customize the Prim+RPC client and
+You're now ready to [learn how to further use Prim+RPC](/docs/features). You can also customize the Prim+RPC client and
 server by following the [configuration reference](/docs/reference/configuration).

--- a/docs/text/usage.mdx
+++ b/docs/text/usage.mdx
@@ -217,25 +217,23 @@ console.log(result1, result1 === result2) // 10, true
 ## Upload Files
 
 You can upload files to Prim+RPC as long as your configured
-[`.methodHandler`](/docs/reference/configuration#methodhandler) supports it. Files (and Blobs) can be sent like so:
+[`.methodHandler`](/docs/reference/configuration#methodhandler) supports it. Files can be sent like so (this example
+uses Node):
 
 <CH.Code>
 
 ```typescript example.ts
 import fs from "node:fs/promises"
-
-/** TypeScript/server utility to ensure given argument is of type T */
-const server = <T>(given: unknown): given is T => typeof window === "undefined"
+import path from "node:path"
 
 /** Upload a file to the server */
-export function uploadFile(someTextFile: File): void
-export function uploadFile(someTextFile: Promise<string>): void
-export function uploadFile(someTextFile: unknown) {
-	if (!server<Promise<string>>(inputs)) {
-		return
+export function uploadFile(file: File) {
+	try {
+		await fs.writeFile(path.resolve("./uploads"), Buffer.from(await file.arrayBuffer()))
+		console.log("Saved uploaded file:", file.name)
+	} catch (error) {
+		console.error("Failed to saved:", file.name, error)
 	}
-	const text = await fs.readFile(await someTextFile, "utf-8")
-	console.log("File contents:", text)
 }
 uploadFile.rpc = true
 ```

--- a/libs/example/src/index.ts
+++ b/libs/example/src/index.ts
@@ -276,18 +276,6 @@ export function uploadTheThing(file: File | import("node:buffer").File) {
 uploadTheThing.rpc = true
 
 /**
- *
- * @param args - Any kind of argument really
- * @returns The arguments you gave
- *
- * @public
- */
-function defaultFunction(...args: unknown[]) {
-	return { args: args.length === 1 ? args[0] : args }
-}
-defaultFunction.rpc = true
-
-/**
  * Make an introduction.
  *
  * @param x Introducee 1
@@ -298,5 +286,17 @@ export function greetings(x: string, y: string) {
 	return `${x}, meet ${y}.`
 }
 greetings.rpc = true
+
+/**
+ *
+ * @param args - Any kind of argument really
+ * @returns The arguments you gave
+ *
+ * @public
+ */
+function defaultFunction(...args: unknown[]) {
+	return { args: args.length === 1 ? args[0] : args }
+}
+defaultFunction.rpc = true
 
 export default defaultFunction

--- a/libs/plugins/src/server/express.test.ts
+++ b/libs/plugins/src/server/express.test.ts
@@ -6,9 +6,13 @@ import { describe, test, beforeEach, afterEach, expect } from "vitest"
 import request from "superwstest"
 import * as module from "@doseofted/prim-example"
 import express from "express"
+import multipartPlugin from "multer"
 import { createPrimServer } from "@doseofted/prim-rpc"
 import { createMethodHandler, expressPrimRpc } from "./express"
+import queryString from "query-string"
+import FormData from "form-data"
 import type { Server } from "node:http"
+import { Blob, File } from "node:buffer"
 
 describe("Express plugin is functional as Prim Plugin", () => {
 	const app = express()
@@ -70,6 +74,95 @@ describe("Express plugin is functional as Express plugin", () => {
 				args,
 				id: 1,
 			})
+			.set("accept", "application/json")
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+		expect(response.headers["content-type"]).toContain("application/json")
+		expect(response.status).toEqual(200)
+		expect(response.body).toEqual(expected)
+	})
+})
+
+describe("Express middleware works with over GET/POST", () => {
+	const prim = createPrimServer({
+		module,
+	})
+	const app = express()
+	app.use(expressPrimRpc({ prim }))
+	let server: Server
+	beforeEach(async () => {
+		await new Promise<void>(resolve => {
+			const done = () => resolve()
+			server = app.listen(0, "localhost", done)
+		})
+	})
+	afterEach(() => {
+		server?.close()
+	})
+	const args = { greeting: "What's up", name: "Ted" }
+	const expected = { id: 1, result: module.sayHello(args) }
+	test("POST requests", async () => {
+		const response = await request(server)
+			.post("/prim")
+			.send({
+				method: "sayHello",
+				args,
+				id: 1,
+			})
+			.set("accept", "application/json")
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+		expect(response.headers["content-type"]).toContain("application/json")
+		expect(response.status).toEqual(200)
+		expect(response.body).toEqual(expected)
+	})
+	test("GET requests", async () => {
+		const url = queryString.stringifyUrl({
+			url: "/prim/sayHello",
+			query: { ...args, "-": 1 },
+		})
+		const response = await request(server).get(url).send().set("accept", "application/json")
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+		expect(response.headers["content-type"]).toContain("application/json")
+		expect(response.status).toEqual(200)
+		expect(response.body).toEqual(expected)
+	})
+})
+
+describe("Express middleware can support files", async () => {
+	const prim = createPrimServer({
+		module,
+		showErrorStack: true,
+	})
+	const app = express()
+	app.use(expressPrimRpc({ prim, multipartPlugin }))
+	let server: Server
+	beforeEach(async () => {
+		await new Promise<void>(resolve => {
+			const done = () => resolve()
+			server = app.listen(0, "localhost", done)
+		})
+	})
+	afterEach(() => {
+		server?.close()
+	})
+	const formData = new FormData()
+	formData.append(
+		"rpc",
+		JSON.stringify({
+			method: "uploadTheThing",
+			args: ["_bin_cool"],
+			id: 1,
+		})
+	)
+	const fileName = "hi.txt"
+	const fileContents = new Blob(["hello"], { type: "text/plain" })
+	const file = new File([fileContents], fileName)
+	formData.append("_bin_cool", await fileContents.text(), fileName)
+	const expected = { id: 1, result: module.uploadTheThing(file) }
+	test("given a text file", async () => {
+		const response = await request(server)
+			.post("/prim")
+			.send(formData.getBuffer())
+			.set("content-type", `multipart/form-data; boundary=${formData.getBoundary()}`)
 			.set("accept", "application/json")
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 		expect(response.headers["content-type"]).toContain("application/json")

--- a/libs/plugins/src/server/express.test.ts
+++ b/libs/plugins/src/server/express.test.ts
@@ -128,10 +128,7 @@ describe("Express middleware works with over GET/POST", () => {
 })
 
 describe("Express middleware can support files", async () => {
-	const prim = createPrimServer({
-		module,
-		showErrorStack: true,
-	})
+	const prim = createPrimServer({ module })
 	const app = express()
 	app.use(expressPrimRpc({ prim, multipartPlugin }))
 	let server: Server

--- a/libs/plugins/src/server/h3.test.ts
+++ b/libs/plugins/src/server/h3.test.ts
@@ -1,0 +1,151 @@
+// Part of the Prim+RPC project ( https://prim.doseofted.me/ )
+// Copyright 2023 Ted Klingenberg
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, test, beforeEach, afterEach, expect } from "vitest"
+import request from "superwstest"
+import * as module from "@doseofted/prim-example"
+import { createPrimServer } from "@doseofted/prim-rpc"
+import { createMethodHandler, defineH3PrimHandler } from "./h3"
+import { createApp, toNodeListener } from "h3"
+import { createServer } from "node:http"
+import queryString from "query-string"
+import FormData from "form-data"
+import { Blob, File } from "node:buffer"
+
+describe("H3 plugin is functional as Prim Plugin", () => {
+	const app = createApp()
+	const server = createServer(toNodeListener(app))
+	const methodHandler = createMethodHandler({ app })
+	createPrimServer({ module, methodHandler })
+	beforeEach(() => {
+		server.listen(0)
+	})
+	afterEach(() => {
+		server.close()
+	})
+	const args = { greeting: "What's up", name: "Ted" }
+	const expected = { id: 1, result: module.sayHello(args) }
+	test("registered as Prim Plugin", async () => {
+		const response = await request(server)
+			.post("/prim")
+			.send({
+				method: "sayHello",
+				args,
+				id: 1,
+			})
+			.set("accept", "application/json")
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+		expect(response.headers["content-type"]).toContain("application/json")
+		expect(response.status).toEqual(200)
+		expect(response.body).toEqual(expected)
+	})
+})
+
+describe("H3 plugin is functional as H3 middleware", () => {
+	const app = createApp()
+	const server = createServer(toNodeListener(app))
+	const prim = createPrimServer({ module })
+	const primHandler = defineH3PrimHandler({ prim })
+	app.use(primHandler)
+	beforeEach(() => {
+		server.listen(0)
+	})
+	afterEach(() => {
+		server.close()
+	})
+	const args = { greeting: "What's up", name: "Ted" }
+	const expected = { id: 1, result: module.sayHello(args) }
+	test("registered as Fastify Plugin", async () => {
+		const response = await request(server)
+			.post("/prim")
+			.send({
+				method: "sayHello",
+				args,
+				id: 1,
+			})
+			.set("accept", "application/json")
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+		expect(response.headers["content-type"]).toContain("application/json")
+		expect(response.status).toEqual(200)
+		expect(response.body).toEqual(expected)
+	})
+})
+
+describe("H3 plugin works with over GET/POST", () => {
+	const app = createApp()
+	const server = createServer(toNodeListener(app))
+	const methodHandler = createMethodHandler({ app })
+	createPrimServer({ module, methodHandler })
+	beforeEach(() => {
+		server.listen(0)
+	})
+	afterEach(() => {
+		server.close()
+	})
+	const args = { greeting: "What's up", name: "Ted" }
+	const expected = { id: 1, result: module.sayHello(args) }
+	test("POST requests", async () => {
+		const response = await request(server)
+			.post("/prim")
+			.send({
+				method: "sayHello",
+				args,
+				id: 1,
+			})
+			.set("accept", "application/json")
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+		expect(response.headers["content-type"]).toContain("application/json")
+		expect(response.status).toEqual(200)
+		expect(response.body).toEqual(expected)
+	})
+	test("GET requests", async () => {
+		const url = queryString.stringifyUrl({
+			url: "/prim/sayHello",
+			query: { ...args, "-": 1 },
+		})
+		const response = await request(server).get(url).send().set("accept", "application/json")
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+		expect(response.headers["content-type"]).toContain("application/json")
+		expect(response.status).toEqual(200)
+		expect(response.body).toEqual(expected)
+	})
+})
+
+describe("Fastify plugin can support files", async () => {
+	const app = createApp()
+	const server = createServer(toNodeListener(app))
+	const methodHandler = createMethodHandler({ app })
+	createPrimServer({ module, methodHandler })
+	beforeEach(() => {
+		server.listen(0)
+	})
+	afterEach(() => {
+		server.close()
+	})
+	const formData = new FormData()
+	formData.append(
+		"rpc",
+		JSON.stringify({
+			method: "uploadTheThing",
+			args: ["_bin_cool"],
+			id: 1,
+		})
+	)
+	const fileName = "hi.txt"
+	const fileContents = new Blob(["hello"], { type: "text/plain" })
+	const file = new File([fileContents], fileName)
+	formData.append("_bin_cool", await fileContents.text(), fileName)
+	const expected = { id: 1, result: module.uploadTheThing(file) }
+	test("given a text file", async () => {
+		const response = await request(server)
+			.post("/prim")
+			.send(formData.getBuffer())
+			.set("content-type", `multipart/form-data; boundary=${formData.getBoundary()}`)
+			.set("accept", "application/json")
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+		expect(response.headers["content-type"]).toContain("application/json")
+		expect(response.status).toEqual(200)
+		expect(response.body).toEqual(expected)
+	})
+})

--- a/libs/plugins/src/server/h3.ts
+++ b/libs/plugins/src/server/h3.ts
@@ -14,9 +14,7 @@ import {
 	App,
 	H3Event,
 } from "h3"
-import { mkdtemp, writeFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { join as joinPath } from "node:path"
+import { File } from "node:buffer"
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface SharedH3Options {
@@ -46,10 +44,8 @@ export function defineH3PrimHandler(options: PrimH3PluginOptions) {
 				if (part.name === "rpc") {
 					body = part.data.toString("utf-8")
 				} else if (part.filename && part.name.startsWith("_bin_")) {
-					const tmpFolder = await mkdtemp(joinPath(tmpdir(), "prim-rpc-"))
-					const tmpFile = joinPath(tmpFolder, part.filename)
-					await writeFile(tmpFile, part.data)
-					blobs[part.name] = tmpFile
+					const file = new File([part.data], part.filename, { type: part.type })
+					blobs[part.name] = file
 				}
 			}
 		} else if (method === "POST") {

--- a/libs/plugins/src/server/nextjs.ts
+++ b/libs/plugins/src/server/nextjs.ts
@@ -17,7 +17,7 @@ interface PrimNextjsAppPluginOptions extends SharedNextjsOptions {
 	contextTransform?: (request: Request) => { context: "nextjs-app"; request: Request }
 }
 
-export function defineNextjsAppHandler(options: PrimNextjsAppPluginOptions) {
+export function defineNextjsAppPrimHandler(options: PrimNextjsAppPluginOptions) {
 	const { prim, headers = {}, contextTransform = request => ({ context: "nextjs-app", request }) } = options
 	async function handler(request: Request) {
 		let body: string

--- a/libs/plugins/src/server/nextjs.ts
+++ b/libs/plugins/src/server/nextjs.ts
@@ -1,11 +1,5 @@
 import type { PrimServerEvents } from "@doseofted/prim-rpc"
 import { File } from "node:buffer"
-import { pipeline } from "node:stream/promises"
-import { createWriteStream } from "node:fs"
-import { mkdtemp } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { join as joinPath } from "node:path"
-import { PipelineSource } from "node:stream"
 // import type { NextApiRequest, NextApiResponse } from "next"
 
 interface SharedNextjsOptions {
@@ -32,27 +26,13 @@ export function defineNextjsAppPrimHandler(options: PrimNextjsAppPluginOptions) 
 		const context = contextTransform(request)
 		if (requestType.startsWith("multipart/form-data")) {
 			const formData = await request.formData()
-			const blobsAdded: Promise<void>[] = []
 			formData.forEach((value, key) => {
-				blobsAdded.push(
-					(async () => {
-						if (key === "rpc") {
-							body = value.toString()
-						} else if (key.startsWith("_bin_") && value instanceof File) {
-							const tmpFolder = await mkdtemp(joinPath(tmpdir(), "prim-rpc-"))
-							const tmpFile = joinPath(tmpFolder, value.name)
-							const filenamePromise = pipeline(
-								value.stream() as PipelineSource<ReadableStream>,
-								createWriteStream(tmpFile)
-							)
-								.then(() => tmpFile)
-								.catch(() => "")
-							blobs[key] = filenamePromise
-						}
-					})()
-				)
+				if (key === "rpc") {
+					body = value.toString()
+				} else if (key.startsWith("_bin_") && value instanceof File) {
+					blobs[key] = value
+				}
 			})
-			await Promise.all(blobsAdded)
 		} else if (method === "POST") {
 			body = await request.text()
 		}

--- a/libs/rpc/src/client.test.ts
+++ b/libs/rpc/src/client.test.ts
@@ -206,14 +206,3 @@ describe("Prim Client can batch RPC calls over HTTP", () => {
 		await expect(result).resolves.toEqual(expected)
 	})
 })
-
-/**
- * NOTE: this is currently handled primarily by plugins so tests should be written there (for now).
- * Once some sort of "blob handler" is used in Prim (see `blobHandler` idea) then these tests can be expanded on.
- */
-// test("Prim Client can send binary contents", async () => {
-// 	const { client, socket, callbackHandler, methodHandler } = createPrimTestingPlugins()
-// 	createPrimServer({ module, callbackHandler, methodHandler })
-// 	const prim = createPrimClient<IModule>({ client, socket, clientBatchTime: 15 })
-// 	const result = await prim.createImaginaryProfile({/* ... */})
-// })

--- a/libs/rpc/src/interfaces.ts
+++ b/libs/rpc/src/interfaces.ts
@@ -215,6 +215,12 @@ export interface PrimOptions<M extends object = object, J extends JsonHandler = 
 	 */
 	handleError?: boolean
 	/**
+	 * This option is `false` by default and only applies when the `.handleError` option is `true`.
+	 * When enabled, the `.stack` property of an error, if present, will be sent to the client.
+	 * This is useful for debugging but should be disabled in production.
+	 */
+	showErrorStack?: boolean
+	/**
 	 * This option only applies if you need to upload files (otherwise, you can ignore).
 	 *
 	 * Prim RPC creates RPC calls formatted as JSON. JSON, by itself, doesn't support binary data. When a function is

--- a/libs/rpc/src/options.ts
+++ b/libs/rpc/src/options.ts
@@ -61,6 +61,9 @@ const createBaseClientOptions = (server = false): PrimOptions => ({
 	// thrown from the server so set this to `true` (if presets are used, this may be set to `false` for
 	// "production" settings)
 	handleError: true,
+	// the error stack shouldn't be shown in production (but can be enabled in development)
+	// NOTE: in the future, this option should probably move so that it isn't dependent on `handleError` option
+	showErrorStack: false,
 	// Assume that default JSON handler is used and handle blobs separately from JSON
 	handleBlobs: true,
 	// !SECTION

--- a/libs/rpc/src/server.ts
+++ b/libs/rpc/src/server.ts
@@ -150,6 +150,9 @@ function createServerActions(
 				// when a custom JSON handler is not provided
 				if (handleError && e instanceof Error) {
 					const error = serializeError<unknown>(e)
+					if (!serverOptions.showErrorStack) {
+						delete error.stack
+					}
 					return { ...rpcBase, error }
 				}
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment


### PR DESCRIPTION
- Added and documented new option `.showErrorStack` (error stack no longer shown by default)
- Created security documentation page describing recommended practices and responsibilities of Prim+RPC in a stack
- Fastify, Express, H3, Next.js integrations no longer save to OS temporary directory (they now use File object)
- Added file handling tests for Fastify, Express, and H3