### PR TITLE
Dynamic imports now supported

### DIFF
--- a/.changeset/kind-teachers-taste.md
+++ b/.changeset/kind-teachers-taste.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc": minor
+---
+
+Module option of client and server now accepts dynamic imports and explicitly setting module value to null

--- a/.changeset/tiny-cameras-watch.md
+++ b/.changeset/tiny-cameras-watch.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc-plugins": patch
+---
+
+.headers is no longer a required parameter on the Next.js plugin

--- a/apps/frontend/src/app/prim/[[...prim]]/route.ts
+++ b/apps/frontend/src/app/prim/[[...prim]]/route.ts
@@ -5,11 +5,4 @@ import jsonHandler from "superjson"
 
 const module = process.env.NODE_ENV === "development" ? moduleAll : { greetings: moduleAll.greetings }
 const prim = createPrimServer({ module, jsonHandler })
-export const { GET, POST } = defineNextjsAppPrimHandler({
-	prim,
-	headers: {
-		"Access-Control-Allow-Origin": "*",
-		"Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-		"Access-Control-Allow-Headers": "Content-Type, Authorization",
-	},
-})
+export const { GET, POST } = defineNextjsAppPrimHandler({ prim })

--- a/apps/frontend/src/app/prim/client.ts
+++ b/apps/frontend/src/app/prim/client.ts
@@ -1,19 +1,13 @@
 import { createPrimClient } from "@doseofted/prim-rpc"
 import { createMethodPlugin, createCallbackPlugin } from "@doseofted/prim-rpc-plugins/browser"
 import jsonHandler from "superjson"
-import type * as module from "@doseofted/prim-example"
+import type * as moduleType from "@doseofted/prim-example"
 
 // const host = process.env.NEXT_PUBLIC_WEBSITE_HOST ?? ""
 // const contained = JSON.parse(process.env.NEXT_PUBLIC_CONTAINED ?? "false") as boolean
 
-const endpoint =
-	typeof window === "undefined"
-		? process.env.VERCEL_URL
-			? `https://${process.env.VERCEL_URL}/prim`
-			: "http://localhost:3000/prim"
-		: "/prim"
-const client = createPrimClient<typeof module>({
-	endpoint,
+const client = createPrimClient<typeof moduleType>({
+	module: typeof window === "undefined" ? import("@doseofted/prim-example") : null,
 	jsonHandler,
 	methodPlugin: createMethodPlugin(),
 	callbackPlugin: createCallbackPlugin(),

--- a/apps/frontend/src/pages/tests/form.tsx
+++ b/apps/frontend/src/pages/tests/form.tsx
@@ -1,9 +1,12 @@
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import backend from "../../app/prim/client"
 
 function Form() {
 	const form = useRef<HTMLFormElement>(null)
 	const [names, setNames] = useState<string[]>([])
+	useEffect(() => {
+		void backend.sayHelloAlternative("Hi", "Ted").then(console.log)
+	}, [])
 	async function handleForm(form: HTMLFormElement) {
 		try {
 			const inputNames = await backend.handleForm(form)

--- a/libs/plugins/src/server/nextjs.ts
+++ b/libs/plugins/src/server/nextjs.ts
@@ -7,7 +7,7 @@ interface SharedNextjsOptions {
 }
 
 interface PrimNextjsAppPluginOptions extends SharedNextjsOptions {
-	headers: Headers | Record<string, string>
+	headers?: Headers | Record<string, string>
 	contextTransform?: (request: Request) => { context: "nextjs-app"; request: Request }
 }
 

--- a/libs/rpc/src/client.test.ts
+++ b/libs/rpc/src/client.test.ts
@@ -34,6 +34,20 @@ describe("Prim Client can call methods with a single parameter", () => {
 		const result = await prim.sayHello(args)
 		expect(result).toEqual(expected)
 	})
+	test("with local source, dynamic import", async () => {
+		const prim = createPrimClient({ module: import("@doseofted/prim-example") })
+		const args = { greeting: "Hi", name: "Ted" }
+		const expected = module.sayHello(args)
+		const result = await prim.sayHello(args)
+		expect(result).toEqual(expected)
+	})
+	test("with local source, function that returns dynamic import", async () => {
+		const prim = createPrimClient({ module: import("@doseofted/prim-example") })
+		const args = { greeting: "Hi", name: "Ted" }
+		const expected = module.sayHello(args)
+		const result = await prim.sayHello(args)
+		expect(result).toEqual(expected)
+	})
 	test("with remote source", async () => {
 		const { callbackPlugin, methodPlugin, callbackHandler, methodHandler } = createPrimTestingPlugins()
 		createPrimServer({ module, callbackHandler, methodHandler })

--- a/libs/rpc/src/index.ts
+++ b/libs/rpc/src/index.ts
@@ -27,5 +27,5 @@ export type {
 	BlobRecords,
 	// other potentially useful utilities
 	AnyFunction,
-	PromisifiedModule,
+	PromisifiedModule as PromisifiedModule,
 } from "./interfaces"

--- a/libs/rpc/src/server.test.ts
+++ b/libs/rpc/src/server.test.ts
@@ -52,6 +52,33 @@ describe("Prim Server can call methods with local module", () => {
 	})
 })
 
+describe("Prim Server can call methods with dynamically imported module", () => {
+	test("dynamic import only", async () => {
+		const prim = createPrimServer({ module: import("@doseofted/prim-example"), prefix: "/prim" })
+		const server = prim.server()
+		const url = queryString.stringifyUrl({
+			url: "/prim/sayHello",
+			query: { greeting: "Salut", name: "Ted" },
+		})
+		const response = await server.call({ method: "GET", url })
+		const result = JSON.parse(response.body) as RpcAnswer
+		expect(result).toEqual({ result: "Salut Ted!" })
+	})
+	test("function that returns a dynamic import", async () => {
+		const prim = createPrimServer({ module: () => import("@doseofted/prim-example"), prefix: "/prim" })
+		const server = prim.server()
+		const call: RpcCall = {
+			method: "sayHello",
+			args: { greeting: "Hola", name: "Ted" },
+			id: 1,
+		}
+		const body = JSON.stringify(call)
+		const response = await server.call({ method: "POST", body })
+		const result = JSON.parse(response.body) as RpcAnswer
+		expect(result).toEqual({ result: "Hola Ted!", id: 1 })
+	})
+})
+
 test("Prim Server can call remote methods (without module directly)", async () => {
 	const { callbackPlugin, methodPlugin, callbackHandler, methodHandler } = createPrimTestingPlugins()
 	createPrimServer({ module, callbackHandler, methodHandler }) // server 1


### PR DESCRIPTION
Now possible (and fully typed):

> **Warning**: this dynamic import should only be used where a bundler eliminates the import in client bundles

```typescript
import type moduleType from "./my-example-module"

const prim = createPrimClient<typeof moduleType>({
  module: process.server ? import("./my-example-module") : null,
  // ... other options
})
```

This is useful for avoiding an extra network call where the module is already available. It's intended to be used in fullstack frameworks where a build tool removes the import during some tree-shaking step (so the client doesn't receive the import).

Technically, a dynamic import isn't required here in most cases. I could just import the code as usual and, because of the `process.server` condition, that import should be removed. However, using a dynamic import better communicates through code the fact that this import should only happen when on the server (even if the behavior in the end is the same).