### PR TITLE
Web Worker Exports Change

### DIFF
--- a/.changeset/two-badgers-retire.md
+++ b/.changeset/two-badgers-retire.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc-plugins": minor
+---
+
+Web Worker plugin now has new jsonHandler export (existing plugins now only return plugin without extra JSON handler)

--- a/apps/frontend/src/components/CodeHighlighted/index.tsx
+++ b/apps/frontend/src/components/CodeHighlighted/index.tsx
@@ -1,6 +1,6 @@
 import { useAsync, useMount } from "react-use"
 import { createPrimClient, PromisifiedModule } from "@doseofted/prim-rpc"
-import { createMethodPlugin, createCallbackPlugin } from "@doseofted/prim-rpc-plugins/web-worker"
+import { createMethodPlugin, createCallbackPlugin, jsonHandler } from "@doseofted/prim-rpc-plugins/web-worker"
 import type { module } from "./worker"
 import { useState } from "react"
 
@@ -16,8 +16,8 @@ export function CodeHighlighted(props: CodeHighlightedProps) {
 	const [worker, setWorker] = useState<PromisifiedModule<typeof module>>()
 	useMount(() => {
 		const worker = new Worker(new URL("./worker", import.meta.url), { type: "module" })
-		const { methodPlugin, jsonHandler } = createMethodPlugin({ worker })
-		const { callbackPlugin } = createCallbackPlugin({ worker })
+		const methodPlugin = createMethodPlugin({ worker })
+		const callbackPlugin = createCallbackPlugin({ worker })
 		const client = createPrimClient<typeof module>({ jsonHandler, methodPlugin, callbackPlugin })
 		setWorker(client)
 	})

--- a/apps/frontend/src/components/CodeHighlighted/worker.ts
+++ b/apps/frontend/src/components/CodeHighlighted/worker.ts
@@ -1,9 +1,9 @@
 import { createPrimServer } from "@doseofted/prim-rpc"
-import { createCallbackHandler, createMethodHandler } from "@doseofted/prim-rpc-plugins/web-worker"
+import { createCallbackHandler, createMethodHandler, jsonHandler } from "@doseofted/prim-rpc-plugins/web-worker"
 import * as module from "./highlight"
 
-const { methodHandler } = createMethodHandler({ worker: self })
-const { callbackHandler, jsonHandler } = createCallbackHandler({ worker: self })
+const methodHandler = createMethodHandler({ worker: self })
+const callbackHandler = createCallbackHandler({ worker: self })
 createPrimServer({ module, methodHandler, callbackHandler, jsonHandler })
 
 export type { module }

--- a/docs/text/plugins/ipc.mdx
+++ b/docs/text/plugins/ipc.mdx
@@ -29,10 +29,10 @@ You can communicate between a Web Worker and the main thread in either direction
 
 ```typescript worker.ts
 import { createPrimServer } from "@doseofted/prim-rpc"
-import { createMethodHandler, createCallbackHandler } from "@doseofted/prim-rpc-plugins/web-worker"
+import { createMethodHandler, createCallbackHandler, jsonHandler } from "@doseofted/prim-rpc-plugins/web-worker"
 
-const { methodHandler, jsonHandler } = createMethodHandler({ worker: self })
-const { callbackHandler } = createCallbackHandler({ worker: self })
+const methodHandler = createMethodHandler({ worker: self })
+const callbackHandler = createCallbackHandler({ worker: self })
 
 createPrimServer({ methodHandler, callbackHandler, jsonHandler })
 ```
@@ -41,20 +41,20 @@ createPrimServer({ methodHandler, callbackHandler, jsonHandler })
 
 ```typescript index.ts
 import { createPrimClient } from "@doseofted/prim-rpc"
-import { createMethodPlugin, createCallbackPlugin } from "@doseofted/prim-rpc-plugins/web-worker"
+import { createMethodPlugin, createCallbackPlugin, jsonHandler } from "@doseofted/prim-rpc-plugins/web-worker"
 
 const worker = new Worker(new URL("./worker", import.meta.url), { type: "module" })
 
-const { methodPlugin, jsonHandler } = createMethodPlugin({ worker })
-const { callbackPlugin } = createCallbackPlugin({ worker })
+const methodPlugin = createMethodPlugin({ worker })
+const callbackPlugin = createCallbackPlugin({ worker })
 
 const client = createPrimClient({ methodPlugin, callbackPlugin, jsonHandler })
 ```
 
 </CH.Code>
 
-Note that all plugins return a `jsonHandler` result and that they are all exactly the same. This is just a helper
-utility that will disable JSON handling. JSON handling should be disabled because Web Workers will use
+Note that the web worker plugin has a `jsonHandler` export. This is just a helper utility that will disable JSON
+handling. JSON handling should be disabled because Web Workers will use
 [structured cloning](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)
 instead which is far more powerful. Of course, you can always override the JSON handler to anything that you'd like if
 you can forgo structured cloning.


### PR DESCRIPTION
JSON handler is no longer returned for all plugins (it was repetitive and unnecessary). New exports:

```typescript
import {
  createMethodHandler, createCallbackHandler,
  createMethodPlugin, createCallbackPlugin,
  jsonHandler
} from "@doseofted/prim-rpc-plugins/web-worker"

const methodHandler = createMethodHandler({ ...options })
const callbackHandler = createCallbackHandler({ ...options })
createPrimServer({ methodHandler, callbackHandler, jsonHandler })

const methodPlugin = createMethodPlugin({ ...options })
const callbackPlugin = createCallbackPlugin({ ...options })
const client = createPrimClient({ methodPlugin, callbackPlugin, jsonHandler })
```