### PR TITLE
Module checks and runtime import check

### DIFF
--- a/.changeset/olive-dryers-give.md
+++ b/.changeset/olive-dryers-give.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc": patch
+---
+
+Fix for dynamic imports used with Prim RPC server

--- a/.changeset/rare-owls-poke.md
+++ b/.changeset/rare-owls-poke.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc": patch
+---
+
+More in-depth checks added for calling module provided to Prim+RPC server

--- a/.changeset/spotty-dryers-wave.md
+++ b/.changeset/spotty-dryers-wave.md
@@ -1,0 +1,6 @@
+---
+"@doseofted/prim-rpc-tooling": minor
+---
+
+New option added to preventImport tool that throws an error if imported on client at run-time (useful for testing with
+fullstack frameworks)

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -33,7 +33,6 @@ createPrimServer({
 	jsonHandler,
 	module: filteredModule,
 	methodHandler,
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
 	callbackHandler,
 	allowList: { startCase: true },
 })

--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -1,6 +1,6 @@
 // @ts-check
-// import path from "node:path"
-// import preventImport from "@doseofted/prim-rpc-tooling/build"
+import path from "node:path"
+import preventImport, { BuildModifyMethod } from "@doseofted/prim-rpc-tooling/build"
 import mdx from "@next/mdx"
 import { remarkCodeHike } from "@code-hike/mdx"
 import { readFileSync } from "fs"
@@ -38,14 +38,14 @@ const nextConfig = withMDX({
 	reactStrictMode: true,
 	swcMinify: true,
 	// NOTE: since server is contained in the Next.js project itself, the module shouldn't be ignored across entire project
-	// webpack(given) {
-	// 	/** @type {import("webpack").Configuration} */
-	// 	const config = given
-	// 	const dirname = new URL("", import.meta.url).pathname
-	// 	const modulePath = path.join(dirname, "../../..", "libs/example")
-	// 	config.plugins?.push(preventImport.webpack({ name: modulePath }))
-	// 	return config
-	// },
+	webpack(given) {
+		/** @type {import("webpack").Configuration} */
+		const config = given
+		const dirname = new URL("", import.meta.url).pathname
+		const modulePath = path.join(dirname, "../../..", "libs/example")
+		config.plugins?.push(preventImport.webpack({ name: modulePath, method: BuildModifyMethod.RunTimeWindowCheck }))
+		return config
+	},
 	pageExtensions: ["ts", "tsx", "js", "jsx", "md", "mdx"],
 })
 

--- a/apps/frontend/src/app/prim/client.ts
+++ b/apps/frontend/src/app/prim/client.ts
@@ -6,11 +6,23 @@ import type * as moduleType from "@doseofted/prim-example"
 // const host = process.env.NEXT_PUBLIC_WEBSITE_HOST ?? ""
 // const contained = JSON.parse(process.env.NEXT_PUBLIC_CONTAINED ?? "false") as boolean
 
+/** Official client to us in website */
 const client = createPrimClient<typeof moduleType>({
 	module: typeof window === "undefined" ? import("@doseofted/prim-example") : null,
+	endpoint: typeof window === "undefined" ? "" : window.location.origin + "/prim",
 	jsonHandler,
 	methodPlugin: createMethodPlugin(),
-	callbackPlugin: createCallbackPlugin(),
 })
 
 export default client
+
+/** Client used for testing that communicates with separate backend in this project. */
+export const testingClient =
+	process.env.NODE_ENV === "development"
+		? createPrimClient<typeof moduleType>({
+				endpoint: "http://localhost:3001/prim",
+				jsonHandler,
+				methodPlugin: createMethodPlugin(),
+				callbackPlugin: createCallbackPlugin(),
+		  })
+		: client

--- a/apps/frontend/src/pages/index.tsx
+++ b/apps/frontend/src/pages/index.tsx
@@ -10,6 +10,10 @@ import Link from "next/link"
 import { Icon } from "@iconify/react"
 import backend from "../app/prim/client"
 
+// This direct import will throw an error (see next.config.js)
+// import { greetings } from "@doseofted/prim-example"
+// console.log(greetings("Backend", "Frontend"))
+
 interface Props {
 	greeting: string
 }
@@ -100,7 +104,7 @@ export default function Home({ greeting }: Props) {
 		{
 			title: "Share Only What's Allowed",
 			details:
-				"As a security precaution, only the functions you explicitly mark as RPC will be callable from Prim+RPC.",
+				"As a security precaution, only the functions you explicitly export and mark as RPC will be callable from Prim+RPC.",
 		},
 		{
 			title: "Generate Documentation",

--- a/apps/frontend/src/pages/tests/callbacks.tsx
+++ b/apps/frontend/src/pages/tests/callbacks.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react"
-import backend from "../../app/prim/client"
+import { testingClient as backend } from "../../app/prim/client"
 
 function Callbacks() {
 	const [typed, setTyped] = useState<string>("")
@@ -19,7 +19,7 @@ function Callbacks() {
 						const message = data.get("message")?.toString() ?? ""
 						setTyped(" ")
 						input.current.value = ""
-						void backend.typeMessage(message, letter => setTyped(typed => typed + letter), 50)
+						void backend.typeMessage(message, letter => setTyped(typed => typed + letter), 150)
 					}}>
 					<input
 						ref={input}

--- a/apps/frontend/src/pages/tests/form.tsx
+++ b/apps/frontend/src/pages/tests/form.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react"
-import backend from "../../app/prim/client"
+import { testingClient as backend } from "../../app/prim/client"
 
 function Form() {
 	const form = useRef<HTMLFormElement>(null)

--- a/apps/frontend/src/pages/tests/greeting.tsx
+++ b/apps/frontend/src/pages/tests/greeting.tsx
@@ -1,5 +1,5 @@
 import { GetServerSideProps } from "next"
-import backend from "../../app/prim/client"
+import { testingClient as backend } from "../../app/prim/client"
 
 interface Props {
 	message: string

--- a/docs/text/security.mdx
+++ b/docs/text/security.mdx
@@ -15,7 +15,7 @@ export default ({ children }) => <LayoutDocs meta={meta}>{children}</LayoutDocs>
 <Alert prose icon="carbon:information">
 
 Prim+RPC does not have a stable release and should not yet be used in production applications. Please report any
-security issues that you find according to the [security policy](https://github.com/doseofted/prim-rpc/security/policy).
+security issues that you find according to the [security policy](https://github.com/doseofted/prim-rpc/security).
 
 </Alert>
 
@@ -275,5 +275,5 @@ Prim+RPC keeps a narrow scope: it handles RPC but it utilizes separate plugins f
 choose any transport that you'd like by using an available plugin or creating your own but it also means that the
 security of the transport falls outside of Prim+RPC's scope. Securing the transport may mean something different
 depending on the environment. For instance, on a web client, you may consider the possibility of XSS. If you're using
-Prim+RPC on a web server then you may consider using TLS, CORS headers, rate limiting, authentication, and other means.
-These are good practices in general for an application and are not specific to Prim+RPC.
+Prim+RPC on a web server then you may consider using TLS, CORS headers, CSRF tokens, rate limiting, authentication, and
+other means. These are good practices in general for an application and are not specific to Prim+RPC.

--- a/libs/example/src/dynamic.ts
+++ b/libs/example/src/dynamic.ts
@@ -1,0 +1,5 @@
+/** Please read the memo attached, thanks. */
+export function synergy() {
+	return "Let's circle back, focus on strategy going forward, and hit the ground running."
+}
+synergy.rpc = true

--- a/libs/example/src/index.ts
+++ b/libs/example/src/index.ts
@@ -20,8 +20,10 @@ export * as additional from "./submodule"
 // external module directly imported (no RPC property added)
 export { startCase } from "lodash-es"
 
-// import things, { ThingInstance, Things } from "./things"
-// export type { ThingInstance }
+export const dynamic = import("./dynamic")
+
+// export { things, Things } from "./things"
+// export type { ThingInstance } from "./things"
 
 /** TODO: Maybe we shouldn't share this. Just a thought. */
 export const superSecret = {
@@ -273,6 +275,17 @@ export function greetings(x: string, y: string) {
 	return `${x}, meet ${y}.`
 }
 greetings.rpc = true
+
+/** I don't even know what's going on here. And that's the point. */
+export function lookAtThisMess() {
+	return "Clean it up!"
+}
+lookAtThisMess.rpc = true
+lookAtThisMess.docs = () => "This is example documentation defined on the function itself."
+lookAtThisMess.somethingMadeUp = () => "Maybe we'll allow it"
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+lookAtThisMess.prototype.somethingMadeUp = () => "Nope"
+lookAtThisMess.messy = { technicallyNotRpc: sayHelloAlternative, definitelyNotRpc: () => "Hi" }
 
 /**
  *

--- a/libs/example/src/things.ts
+++ b/libs/example/src/things.ts
@@ -30,9 +30,8 @@ export class Things {
 		return true
 	}
 }
-const things = new Things()
 
 /**
  * Work on things.
  */
-export default things
+export const things = new Things()

--- a/libs/example/tsconfig.json
+++ b/libs/example/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "ES2020",
+		"module": "ES2020",
 		"moduleResolution": "Node",
 		"esModuleInterop": true,
 		"isolatedModules": true,

--- a/libs/rpc/src/client.ts
+++ b/libs/rpc/src/client.ts
@@ -65,7 +65,6 @@ export function createPrimClient<
 		| Promise<ModuleType>
 	// SECTION Proxy to handle function calls
 	const proxy = new ProxyDeep<ModuleType>({} as ModuleType, {
-		// FIXME: I need to make sure returned proxy is not a promise (this may not work, promise should be resolved first)
 		apply(_target, targetContext, givenArgs: unknown[]) {
 			// NOTE: client could've been given either Promise or function that resolves to Promise (dynamic imports)
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/libs/rpc/src/interfaces.ts
+++ b/libs/rpc/src/interfaces.ts
@@ -4,7 +4,6 @@
 
 import type { Emitter } from "mitt"
 import type { Schema } from "type-fest"
-import type { Asyncify } from "type-fest"
 
 // SECTION RPC call and result structure
 interface RpcBase {
@@ -66,8 +65,8 @@ export type AnyFunction = (...args: any[]) => any
 // NOTE: Asyncify might need to be replaced since TSDoc comments aren't shown in editor when used
 // NOTE: consider condition of checking `.rpc` property on function (but also remember that it may be in allow list)
 type PromisifiedModuleDirect<ModuleGiven extends object> = {
-	[Key in keyof ModuleGiven]: ModuleGiven[Key] extends AnyFunction
-		? Asyncify<ModuleGiven[Key]>
+	[Key in keyof ModuleGiven]: ModuleGiven[Key] extends (...args: infer A) => infer R
+		? (...args: A) => Promise<R>
 		: ModuleGiven[Key] extends object
 		? PromisifiedModuleDirect<ModuleGiven[Key]>
 		: ModuleGiven[Key]

--- a/libs/rpc/src/interfaces.ts
+++ b/libs/rpc/src/interfaces.ts
@@ -65,8 +65,8 @@ export type AnyFunction = (...args: any[]) => any
 // NOTE: Asyncify might need to be replaced since TSDoc comments aren't shown in editor when used
 // NOTE: consider condition of checking `.rpc` property on function (but also remember that it may be in allow list)
 type PromisifiedModuleDirect<ModuleGiven extends object> = {
-	[Key in keyof ModuleGiven]: ModuleGiven[Key] extends (...args: infer A) => infer R
-		? (...args: A) => Promise<R>
+	[Key in keyof ModuleGiven]: ModuleGiven[Key] extends ((...args: infer A) => infer R) & object
+		? ((...args: A) => Promise<R>) & PromisifiedModuleDirect<ModuleGiven[Key]>
 		: ModuleGiven[Key] extends object
 		? PromisifiedModuleDirect<ModuleGiven[Key]>
 		: ModuleGiven[Key]

--- a/libs/rpc/src/server.ts
+++ b/libs/rpc/src/server.ts
@@ -34,12 +34,30 @@ import type {
  */
 function createPrimInstance(options?: PrimServerOptions) {
 	const configured = createPrimOptions(options)
-	const socketEvent = mitt<PrimWebSocketEvents>()
-	const clientEvent = mitt<PrimHttpEvents>()
-	configured.internal = { socketEvent, clientEvent }
+	if (!configured.internal.clientEvent) {
+		configured.internal.clientEvent = mitt<PrimHttpEvents>()
+	}
+	if (!configured.internal.socketEvent) {
+		configured.internal.socketEvent = mitt<PrimWebSocketEvents>()
+	}
 	const client = createPrimClient(configured)
+	const { socketEvent, clientEvent } = configured.internal
 	return { client, socketEvent, clientEvent, configured }
 }
+
+const denyList = [
+	"prototype",
+	"__proto__",
+	"constructor",
+	"toString",
+	"toLocaleString",
+	"valueOf",
+	"apply",
+	"bind",
+	"call",
+	"arguments",
+	"caller",
+]
 
 function createServerActions(
 	serverOptions: PrimServerOptions,
@@ -95,40 +113,54 @@ function createServerActions(
 		const { client, socketEvent: event, configured } = instance ?? createPrimInstance(serverOptions)
 		const callList = Array.isArray(calls) ? calls : [calls]
 		const answeringCalls = callList.map(async (given): Promise<RpcAnswer> => {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 			const { method, args, id } = given
 			const rpcVersion: Partial<RpcAnswer> = useVersionInRpc ? { prim: primMajorVersion } : {}
 			const rpcBase: Partial<RpcAnswer> = { ...rpcVersion, id }
 			try {
 				const methodExpanded = method.split("/")
 				// using `configured.module` if module was provided directly to server
-				// resolve given module if it was dynamically imported
+				// and resolve given module first if it was dynamically imported
 				const givenModulePromise = (
 					typeof configured.module === "function" ? configured.module() : configured.module
 				) as PrimServerOptions["module"] | Promise<PrimServerOptions["module"]>
 				const givenModule = givenModulePromise instanceof Promise ? await givenModulePromise : givenModulePromise
 				const targetLocal = getProperty(givenModule, methodExpanded) as AnyFunction & { rpc?: boolean }
-				// using `client` to request remote module if not provided directly to server
-				const targetRemote = getProperty(client, methodExpanded) as AnyFunction & { rpc?: boolean }
-				const target = targetLocal ?? targetRemote
-				if (targetLocal) {
-					// these checks only apply if module is provided directly (TBD on actual server with module)
+				if (givenModule instanceof Promise) console.warn("DEBUG", givenModule, targetLocal)
+				if (givenModule) {
+					// While subsequent checks cover these situations, some key props will immediately invalidate a given method
+					if (denyList.filter(given => methodExpanded.includes(given)).length > 0) {
+						return { ...rpcBase, error: "Method was not valid" }
+					}
+					// these checks only apply if module is provided directly (determined on actual server with module)
 					if (methodExpanded.length > 1) {
-						const previousPath = getProperty(givenModule, methodExpanded.slice(0, -1)) as unknown
+						const currentPathCheck: string[] = []
+						// NOTE: `.methodsOnMethods` is only allowed if method is defined _directly_ on another method
+						const previousPathsIncludeFunction = methodExpanded
+							.slice(0, serverOptions.methodsOnMethods.length > 0 ? -2 : -1)
+							.map(method => {
+								currentPathCheck.push(method)
+								const currentPath = getProperty(givenModule, currentPathCheck) as unknown
+								return typeof currentPath !== "object" // paths cannot contain "function" type any other type
+							})
+							.reduce((a, b) => a || b, false)
+						if (previousPathsIncludeFunction) {
+							return { ...rpcBase, error: "Method on method was not valid" }
+						}
+						const directPreviousPath = getProperty(givenModule, methodExpanded.slice(0, -1)) as unknown
 						const disallowedMethodOnMethod =
-							typeof previousPath === "function" &&
+							typeof directPreviousPath === "function" &&
 							!serverOptions.methodsOnMethods.includes(methodExpanded.slice(-1)[0])
 						if (disallowedMethodOnMethod) {
 							return { ...rpcBase, error: "Method on method was not allowed" }
 						}
 					}
-					if (typeof target === "undefined") {
+					if (typeof targetLocal === "undefined" || targetLocal === null) {
 						return { ...rpcBase, error: "Method was not found" }
 					}
-					if (typeof target !== "function") {
+					if (typeof targetLocal !== "function") {
 						return { ...rpcBase, error: "Method was not callable" }
 					}
-					const methodAllowedDirectly = "rpc" in target && typeof target.rpc == "boolean" && target.rpc
+					const methodAllowedDirectly = "rpc" in targetLocal && typeof targetLocal.rpc == "boolean" && targetLocal.rpc
 					if (!methodAllowedDirectly) {
 						const allowedInSchema =
 							Object.entries(serverOptions.allowList ?? {}).length > 0 &&
@@ -141,15 +173,34 @@ function createServerActions(
 				const argsArray = Array.isArray(args) ? args : [args]
 				const argsForCall =
 					Object.entries(blobs || {}).length > 0 ? argsArray.map(arg => mergeBlobLikeWithGiven(arg, blobs)) : argsArray
-				if (cbResults) {
-					event.on("response", cbResults)
+				// NOTE: use `targetRemote` below even if target is local to allow callbacks to be used with server
+				// (server and client share event handlers on `.internal` option that allows for usage of callbacks)
+				if (givenModule && targetLocal) {
+					// The module was provided and the target exists. Checks have already run and did not return an error
+					// so we can call the method using the client.
+					if (cbResults) {
+						event.on("response", cbResults)
+					}
+					// call module with `client` if not provided directly to server (checks already ran on module, if provided)
+					const targetRemote = getProperty(client, methodExpanded) as AnyFunction & { rpc?: boolean }
+					const result = (await Reflect.apply(targetRemote, context, argsForCall)) as unknown
+					return { ...rpcBase, result }
+				} else {
+					// If either the module wasn't provided or target doesn't exist (even if module does), send a request using
+					// a client that doesn't know about the module provided (will use provided plugin to server).
+					// eslint-disable-next-line @typescript-eslint/no-unused-vars
+					const { module: moduleProvided, ...limitedOptions } = serverOptions
+					// create client that doesn't have access to module (target may not exist but other targets might)
+					const { client: limitedClient, socketEvent: limitedEvent } = createPrimInstance(limitedOptions)
+					if (cbResults) {
+						limitedEvent.on("response", cbResults)
+					}
+					const targetRemote = getProperty(limitedClient, methodExpanded) as AnyFunction & { rpc?: boolean }
+					const result = (await Reflect.apply(targetRemote, context, argsForCall)) as unknown
+					return { ...rpcBase, result }
 				}
-				// NOTE: use `remoteTarget` (even if target is local) to ensure callbacks are handled properly by Prim client
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				const result: RpcAnswer = await Reflect.apply(targetRemote, context, argsForCall)
 				// TODO: today, result must be supported by JSON handler but consider supporting returned functions
 				// in the same way that callback are supported today (by passing reference to client)
-				return { ...rpcBase, result }
 			} catch (e) {
 				// JSON.stringify on Error results in an empty object. Since Error is common, serialize it
 				// when a custom JSON handler is not provided
@@ -160,7 +211,6 @@ function createServerActions(
 					}
 					return { ...rpcBase, error }
 				}
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 				return { ...rpcBase, error: e }
 			}
 		})
@@ -257,7 +307,6 @@ function createSocketEvents(serverOptions: PrimServerOptions): PrimServerSocketE
  * @param options Options for utilizing functions provided with Prim
  * @returns A function that expects JSON resembling an RPC call
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createPrimServer<
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	ModuleType extends OptionsType["module"] = object,
@@ -269,7 +318,7 @@ export function createPrimServer<
 	// client options should be re-instantiated on every request
 	// TODO: instead of merging options, considering adding client options to server options as separate property
 	// and creating client options separately from server
-	const serverOptions = createPrimOptions(options, true)
+	const serverOptions = Object.freeze(Object.assign({}, createPrimOptions(options, true)))
 	// TODO: consider emitting some kind of event once handlers are configured (for all that have resolved promises)
 	// this could be useful for plugins of a server framework where plugins must be given and resolved in order
 	const handlersRegistered = Promise.allSettled([
@@ -281,7 +330,7 @@ export function createPrimServer<
 	return {
 		connected,
 		...createServerEvents(serverOptions),
-		options: Object.freeze(Object.assign({}, serverOptions)),
+		options: serverOptions,
 		handlersRegistered,
 	}
 }

--- a/libs/tooling/src/build/index.ts
+++ b/libs/tooling/src/build/index.ts
@@ -4,19 +4,89 @@
 
 import { createUnplugin } from "unplugin"
 
-interface BuildOptions {
+export enum BuildModifyMethod {
+	/**
+	 * Replace all code in given directory with an empty export for each file:
+	 *
+	 * ```typescript
+	 * export {};
+	 * ```
+	 */
+	BuildTimeEmptyExport = "build-time-empty-export",
+	/**
+	 * Add a runtime check to prevent imports from being used on the client.
+	 * While this does not prevent the import from being bundled, it should flag
+	 * an error in your testing process so that you can take action.
+	 *
+	 * The following will be added to the top of each file:
+	 *
+	 * ```typescript
+	 * if (!process.server) { throw new Error("YOUR MESSAGE"); }
+	 * ```
+	 */
+	RunTimeProcessCheck = "run-time-process-check",
+	/**
+	 * This is the same option as "run-time-process-check" except instead of checking
+	 * the `process` object, it checks that the `window` object isn't undefined.
+	 *
+	 * See `"run-time-process-check"` for more details.
+	 */
+	RunTimeWindowCheck = "run-time-window-check",
+}
+
+export interface BuildOptions {
 	/** Folder name, relative to project folder that should not be imported */
 	name: string
 	/** Enable console logs for imports to determine what name option should be used */
 	debug?: boolean
+	/** If a given `.method` is a run-time check, what message should be given to created Error? */
+	runtimeError?: string
+	/**
+	 * Specify method of preventing import.
+	 * Methods are prefixed "build-time-" to prevent code from being bundled
+	 * or "run-time-" to prevent code from being used (but still bundled).
+	 */
+	method?: BuildModifyMethod
 }
 
-export default createUnplugin((options: BuildOptions = { name: "" }) => ({
-	name: "unplugin-prim-prevent-import",
-	transformInclude: id => {
-		const matches = id.startsWith(options.name)
-		if (options.debug) console.log((matches ? "match:" : "no match:").padEnd(10), id)
-		return matches
-	},
-	transform: () => "export {};",
-}))
+const pluginDefaults = {
+	name: "",
+	method: BuildModifyMethod.BuildTimeEmptyExport,
+	runtimeError: "Prim+RPC cannot be started.",
+	debug: false,
+}
+
+export default createUnplugin((options: BuildOptions) => {
+	const configured = { ...pluginDefaults, ...options }
+	return {
+		name: "unplugin-prim-prevent-import",
+		transformInclude: id => {
+			const matches = id.startsWith(configured.name)
+			if (configured.debug) console.log((matches ? "match:" : "no match:").padEnd(10), id)
+			return matches
+		},
+		transform: (originalCode, _id) => {
+			let code: string = null
+			switch (configured.method) {
+				case BuildModifyMethod.RunTimeProcessCheck: {
+					code = `if (!process.server) { throw new Error(${JSON.stringify(
+						configured.runtimeError
+					)}); }\n\n${originalCode}`
+					break
+				}
+				case BuildModifyMethod.RunTimeWindowCheck: {
+					code = `if (typeof window !== "undefined") { throw new Error(${JSON.stringify(
+						configured.runtimeError
+					)}); }\n\n${originalCode}`
+					break
+				}
+				case BuildModifyMethod.BuildTimeEmptyExport:
+				default: {
+					code = "export {};"
+					break
+				}
+			}
+			return { code }
+		},
+	}
+})


### PR DESCRIPTION
- Adds new module checks on Prim+RPC server (along with more tests)
- Prevent Import tool now has run-time check that throws error on import (useful when code is tested before deployed)