### PR TITLE
Additional request/response checks on server

### DIFF
--- a/.changeset/happy-sloths-learn.md
+++ b/.changeset/happy-sloths-learn.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc": patch
+---
+
+Fix for broken type definitions (introduced in last version) on async functions used with client

--- a/.changeset/warm-walls-design.md
+++ b/.changeset/warm-walls-design.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc": minor
+---
+
+Errors are now better handled during processing of HTTP-like requests/responses and processing of RPC calls/results

--- a/libs/example/src/index.ts
+++ b/libs/example/src/index.ts
@@ -80,6 +80,21 @@ export function sayHelloAlternative(greeting: string, name: string) {
 }
 sayHelloAlternative.rpc = true
 
+/** Patience is a virtue and I hope that you can respect my time. */
+export async function takeYourTime(howMuch = 300, statusCb?: (status: string) => void) {
+	const excuses = ["I'm busy.", "Gimme a minute.", "I'm almost ready."]
+	statusCb?.(excuses.pop())
+	const interval = setInterval(() => {
+		statusCb?.(excuses.pop())
+		if (excuses.length === 0) {
+			clearInterval(interval)
+		}
+	}, howMuch / 4)
+	await new Promise(resolve => setTimeout(resolve, howMuch))
+	return "I'm ready, let's go."
+}
+takeYourTime.rpc = true
+
 /**
  * This is an example of an entire that module that might be exported.
  *

--- a/libs/rpc/src/error.ts
+++ b/libs/rpc/src/error.ts
@@ -1,0 +1,17 @@
+enum PrimErr {
+	InvalidRpcResult = 0,
+}
+
+const errorMessages = {
+	[PrimErr.InvalidRpcResult]: "Invalid RPC result",
+}
+
+export class PrimRpcError extends Error {
+	public primRpc = true
+
+	constructor(public code: PrimErr, messageOverride?: string) {
+		super(messageOverride || errorMessages[code])
+	}
+}
+
+// const err = new PrimRpcError(PrimErr.InvalidRpcResult)

--- a/libs/rpc/src/interfaces.ts
+++ b/libs/rpc/src/interfaces.ts
@@ -62,11 +62,10 @@ interface PrimWebSocketFunctionEvents {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyFunction = (...args: any[]) => any
-// NOTE: Asyncify might need to be replaced since TSDoc comments aren't shown in editor when used
 // NOTE: consider condition of checking `.rpc` property on function (but also remember that it may be in allow list)
 type PromisifiedModuleDirect<ModuleGiven extends object> = {
 	[Key in keyof ModuleGiven]: ModuleGiven[Key] extends ((...args: infer A) => infer R) & object
-		? ((...args: A) => Promise<R>) & PromisifiedModuleDirect<ModuleGiven[Key]>
+		? ((...args: A) => Promise<Awaited<R>>) & ModuleGiven[Key]
 		: ModuleGiven[Key] extends object
 		? PromisifiedModuleDirect<ModuleGiven[Key]>
 		: ModuleGiven[Key]

--- a/libs/rpc/src/interfaces.ts
+++ b/libs/rpc/src/interfaces.ts
@@ -6,7 +6,7 @@ import type { Emitter } from "mitt"
 import type { Schema } from "type-fest"
 
 // SECTION RPC call and result structure
-interface RpcBase {
+export interface RpcBase {
 	prim?: 0 // as new major versions are announced (only that change message structure), bump version
 	id?: string | number
 }

--- a/libs/rpc/src/server.ts
+++ b/libs/rpc/src/server.ts
@@ -66,43 +66,48 @@ function createServerActions(
 ): PrimServerActionsBase {
 	const { jsonHandler, prefix: serverPrefix, handleError } = serverOptions
 	const prepareCall = (given: CommonServerSimpleGivenOptions = {}): RpcCall | RpcCall[] => {
-		const givenReq = checkHttpLikeRequest(given)
-		const { body, method, url: possibleUrl } = givenReq
-		const providedBody = method === "POST" && body
-		if (providedBody) {
-			const prepared = jsonHandler.parse(givenReq.body) as RpcCall | RpcCall[]
-			return prepared
-		}
-		const providedUrl = method === "GET" && possibleUrl
-		if (providedUrl) {
-			const positional = []
-			const { query, url } = queryString.parseUrl(possibleUrl, {
-				arrayFormat: "comma",
-				parseBooleans: true,
-				parseNumbers: true,
-			})
-			const id: string | number = "-" in query && !Array.isArray(query["-"]) ? query["-"] : undefined
-			delete query["-"]
-			const entries = Object.entries(query)
-			// determine if positional arguments were given (must start at 0, none can be missing)
-			for (const [possibleIndex, value] of entries) {
-				const index = Number.parseInt(possibleIndex)
-				if (Number.isNaN(index)) {
-					break
-				}
-				const nextIndex = index === 0 || typeof positional[index - 1] !== "undefined"
-				if (!nextIndex) {
-					break
-				}
-				positional[index] = value
+		try {
+			const givenReq = checkHttpLikeRequest(given)
+			const { body, method, url: possibleUrl } = givenReq
+			const providedBody = method === "POST" && body
+			if (providedBody) {
+				const prepared = jsonHandler.parse(givenReq.body) as RpcCall | RpcCall[]
+				return prepared
 			}
-			const args =
-				positional.length > 0 && positional.length === entries.length ? positional : entries.length === 0 ? [] : query
-			let method = url.replace(RegExp("^" + serverPrefix + "\\/?"), "")
-			method = method !== "" ? method : "default"
-			return { id, method, args }
+			const providedUrl = method === "GET" && possibleUrl
+			if (providedUrl) {
+				const positional = []
+				const { query, url } = queryString.parseUrl(possibleUrl, {
+					arrayFormat: "comma",
+					parseBooleans: true,
+					parseNumbers: true,
+				})
+				const id: string | number = "-" in query && !Array.isArray(query["-"]) ? query["-"] : undefined
+				delete query["-"]
+				const entries = Object.entries(query)
+				// determine if positional arguments were given (must start at 0, none can be missing)
+				for (const [possibleIndex, value] of entries) {
+					const index = Number.parseInt(possibleIndex)
+					if (Number.isNaN(index)) {
+						break
+					}
+					const nextIndex = index === 0 || typeof positional[index - 1] !== "undefined"
+					if (!nextIndex) {
+						break
+					}
+					positional[index] = value
+				}
+				const args =
+					positional.length > 0 && positional.length === entries.length ? positional : entries.length === 0 ? [] : query
+				let method = url.replace(RegExp("^" + serverPrefix + "\\/?"), "")
+				method = method !== "" ? method : "default"
+				return { id, method, args }
+			}
+			throw { error: "Response can not be generated from request" }
+		} catch (error) {
+			// RPC call is purposefully invalid to trigger invalid RPC error in next step
+			return { method: "" }
 		}
-		throw { error: "Response can not be generated from request" }
 	}
 	const prepareRpc = async (
 		calls: RpcCall | RpcCall[],
@@ -111,111 +116,120 @@ function createServerActions(
 		cbResults?: (a: RpcAnswer) => void
 	): Promise<RpcAnswer | RpcAnswer[]> => {
 		// NOTE: new Prim client should be created on each request so callback results are not shared
-		const { client, socketEvent: event, configured } = instance ?? createPrimInstance(serverOptions)
-		const callList = Array.isArray(calls) ? checkRpcCall(calls) : checkRpcCall([calls])
-		const answeringCalls = callList.map(async (given): Promise<RpcAnswer> => {
-			const { method, args, id } = given
-			const rpcVersion: Partial<RpcAnswer> = useVersionInRpc ? { prim: primMajorVersion } : {}
-			const rpcBase: Partial<RpcAnswer> = { ...rpcVersion, id }
-			try {
-				const methodExpanded = method.split("/")
-				// using `configured.module` if module was provided directly to server
-				// and resolve given module first if it was dynamically imported
-				const givenModulePromise = (
-					typeof configured.module === "function" ? configured.module() : configured.module
-				) as PrimServerOptions["module"] | Promise<PrimServerOptions["module"]>
-				const givenModule = givenModulePromise instanceof Promise ? await givenModulePromise : givenModulePromise
-				const targetLocal = getProperty(givenModule, methodExpanded) as AnyFunction & { rpc?: boolean }
-				if (givenModule) {
-					// While subsequent checks cover these situations, some key props will immediately invalidate a given method
-					if (denyList.filter(given => methodExpanded.includes(given)).length > 0) {
-						return { ...rpcBase, error: "Method was not valid" }
-					}
-					// these checks only apply if module is provided directly (determined on actual server with module)
-					if (methodExpanded.length > 1) {
-						const currentPathCheck: string[] = []
-						// NOTE: `.methodsOnMethods` is only allowed if method is defined _directly_ on another method
-						const previousPathsIncludeFunction = methodExpanded
-							.slice(0, serverOptions.methodsOnMethods.length > 0 ? -2 : -1)
-							.map(method => {
-								currentPathCheck.push(method)
-								const currentPath = getProperty(givenModule, currentPathCheck) as unknown
-								return typeof currentPath !== "object" // paths cannot contain "function" type any other type
-							})
-							.reduce((a, b) => a || b, false)
-						if (previousPathsIncludeFunction) {
-							return { ...rpcBase, error: "Method on method was not valid" }
+		try {
+			const { client, socketEvent: event, configured } = instance ?? createPrimInstance(serverOptions)
+			const callList = Array.isArray(calls) ? checkRpcCall(calls) : checkRpcCall([calls])
+			const answeringCalls = callList.map(async (given): Promise<RpcAnswer> => {
+				const { method, args, id } = given
+				const rpcVersion: Partial<RpcAnswer> = useVersionInRpc ? { prim: primMajorVersion } : {}
+				const rpcBase: Partial<RpcAnswer> = { ...rpcVersion, id }
+				try {
+					const methodExpanded = method.split("/")
+					// using `configured.module` if module was provided directly to server
+					// and resolve given module first if it was dynamically imported
+					const givenModulePromise = (
+						typeof configured.module === "function" ? configured.module() : configured.module
+					) as PrimServerOptions["module"] | Promise<PrimServerOptions["module"]>
+					const givenModule = givenModulePromise instanceof Promise ? await givenModulePromise : givenModulePromise
+					const targetLocal = getProperty(givenModule, methodExpanded) as AnyFunction & { rpc?: boolean }
+					if (givenModule) {
+						// While subsequent checks cover these situations, some key props will immediately invalidate a given method
+						if (denyList.filter(given => methodExpanded.includes(given)).length > 0) {
+							return { ...rpcBase, error: "Method was not valid" }
 						}
-						const directPreviousPath = getProperty(givenModule, methodExpanded.slice(0, -1)) as unknown
-						const disallowedMethodOnMethod =
-							typeof directPreviousPath === "function" &&
-							!serverOptions.methodsOnMethods.includes(methodExpanded.slice(-1)[0])
-						if (disallowedMethodOnMethod) {
-							return { ...rpcBase, error: "Method on method was not allowed" }
+						// these checks only apply if module is provided directly (determined on actual server with module)
+						if (methodExpanded.length > 1) {
+							const currentPathCheck: string[] = []
+							// NOTE: `.methodsOnMethods` is only allowed if method is defined _directly_ on another method
+							const previousPathsIncludeFunction = methodExpanded
+								.slice(0, serverOptions.methodsOnMethods.length > 0 ? -2 : -1)
+								.map(method => {
+									currentPathCheck.push(method)
+									const currentPath = getProperty(givenModule, currentPathCheck) as unknown
+									return typeof currentPath !== "object" // paths cannot contain "function" type any other type
+								})
+								.reduce((a, b) => a || b, false)
+							if (previousPathsIncludeFunction) {
+								return { ...rpcBase, error: "Method on method was not valid" }
+							}
+							const directPreviousPath = getProperty(givenModule, methodExpanded.slice(0, -1)) as unknown
+							const disallowedMethodOnMethod =
+								typeof directPreviousPath === "function" &&
+								!serverOptions.methodsOnMethods.includes(methodExpanded.slice(-1)[0])
+							if (disallowedMethodOnMethod) {
+								return { ...rpcBase, error: "Method on method was not allowed" }
+							}
+						}
+						if (typeof targetLocal === "undefined" || targetLocal === null) {
+							return { ...rpcBase, error: "Method was not found" }
+						}
+						if (typeof targetLocal !== "function") {
+							return { ...rpcBase, error: "Method was not callable" }
+						}
+						const methodAllowedDirectly = "rpc" in targetLocal && typeof targetLocal.rpc == "boolean" && targetLocal.rpc
+						if (!methodAllowedDirectly) {
+							const allowedInSchema =
+								Object.entries(serverOptions.allowList ?? {}).length > 0 &&
+								!!getProperty(serverOptions.allowList, methodExpanded)
+							if (!allowedInSchema) {
+								return { ...rpcBase, error: "Method was not allowed" }
+							}
 						}
 					}
-					if (typeof targetLocal === "undefined" || targetLocal === null) {
-						return { ...rpcBase, error: "Method was not found" }
-					}
-					if (typeof targetLocal !== "function") {
-						return { ...rpcBase, error: "Method was not callable" }
-					}
-					const methodAllowedDirectly = "rpc" in targetLocal && typeof targetLocal.rpc == "boolean" && targetLocal.rpc
-					if (!methodAllowedDirectly) {
-						const allowedInSchema =
-							Object.entries(serverOptions.allowList ?? {}).length > 0 &&
-							!!getProperty(serverOptions.allowList, methodExpanded)
-						if (!allowedInSchema) {
-							return { ...rpcBase, error: "Method was not allowed" }
+					const argsArray = args as unknown[] // already validated in `checkRpcCall`
+					const argsForCall =
+						Object.entries(blobs || {}).length > 0
+							? argsArray.map(arg => mergeBlobLikeWithGiven(arg, blobs))
+							: argsArray
+					// NOTE: use `targetRemote` below even if target is local to allow callbacks to be used with server
+					// (server and client share event handlers on `.internal` option that allows for usage of callbacks)
+					if (givenModule && targetLocal) {
+						// The module was provided and the target exists. Checks have already run and did not return an error
+						// so we can call the method using the client.
+						if (cbResults) {
+							event.on("response", cbResults)
 						}
+						// call module with `client` if not provided directly to server (checks already ran on module, if provided)
+						const targetRemote = getProperty(client, methodExpanded) as AnyFunction & { rpc?: boolean }
+						const result = (await Reflect.apply(targetRemote, context, argsForCall)) as unknown
+						return { ...rpcBase, result }
+					} else {
+						// If either the module wasn't provided or target doesn't exist (even if module does), send a request using
+						// a client that doesn't know about the module provided (will use provided plugin to server).
+						// eslint-disable-next-line @typescript-eslint/no-unused-vars
+						const { module: moduleProvided, ...limitedOptions } = serverOptions
+						// create client that doesn't have access to module (target may not exist but other targets might)
+						const { client: limitedClient, socketEvent: limitedEvent } = createPrimInstance(limitedOptions)
+						if (cbResults) {
+							limitedEvent.on("response", cbResults)
+						}
+						const targetRemote = getProperty(limitedClient, methodExpanded) as AnyFunction & { rpc?: boolean }
+						const result = (await Reflect.apply(targetRemote, context, argsForCall)) as unknown
+						return { ...rpcBase, result }
 					}
+					// TODO: today, result must be supported by JSON handler but consider supporting returned functions
+					// in the same way that callback are supported today (by passing reference to client)
+				} catch (e) {
+					// JSON.stringify on Error results in an empty object. Since Error is common, serialize it
+					// when a custom JSON handler is not provided
+					if (handleError && e instanceof Error) {
+						const error = serializeError<unknown>(e)
+						if (!serverOptions.showErrorStack) {
+							delete error.stack
+						}
+						return { ...rpcBase, error }
+					}
+					return { ...rpcBase, error: e }
 				}
-				const argsArray = args as unknown[] // already validated in `checkRpcCall`
-				const argsForCall =
-					Object.entries(blobs || {}).length > 0 ? argsArray.map(arg => mergeBlobLikeWithGiven(arg, blobs)) : argsArray
-				// NOTE: use `targetRemote` below even if target is local to allow callbacks to be used with server
-				// (server and client share event handlers on `.internal` option that allows for usage of callbacks)
-				if (givenModule && targetLocal) {
-					// The module was provided and the target exists. Checks have already run and did not return an error
-					// so we can call the method using the client.
-					if (cbResults) {
-						event.on("response", cbResults)
-					}
-					// call module with `client` if not provided directly to server (checks already ran on module, if provided)
-					const targetRemote = getProperty(client, methodExpanded) as AnyFunction & { rpc?: boolean }
-					const result = (await Reflect.apply(targetRemote, context, argsForCall)) as unknown
-					return { ...rpcBase, result }
-				} else {
-					// If either the module wasn't provided or target doesn't exist (even if module does), send a request using
-					// a client that doesn't know about the module provided (will use provided plugin to server).
-					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					const { module: moduleProvided, ...limitedOptions } = serverOptions
-					// create client that doesn't have access to module (target may not exist but other targets might)
-					const { client: limitedClient, socketEvent: limitedEvent } = createPrimInstance(limitedOptions)
-					if (cbResults) {
-						limitedEvent.on("response", cbResults)
-					}
-					const targetRemote = getProperty(limitedClient, methodExpanded) as AnyFunction & { rpc?: boolean }
-					const result = (await Reflect.apply(targetRemote, context, argsForCall)) as unknown
-					return { ...rpcBase, result }
-				}
-				// TODO: today, result must be supported by JSON handler but consider supporting returned functions
-				// in the same way that callback are supported today (by passing reference to client)
-			} catch (e) {
-				// JSON.stringify on Error results in an empty object. Since Error is common, serialize it
-				// when a custom JSON handler is not provided
-				if (handleError && e instanceof Error) {
-					const error = serializeError<unknown>(e)
-					if (!serverOptions.showErrorStack) {
-						delete error.stack
-					}
-					return { ...rpcBase, error }
-				}
-				return { ...rpcBase, error: e }
+			})
+			const answeredCalls = checkRpcResult(await Promise.all(answeringCalls))
+			return answeredCalls.length === 1 ? answeredCalls[0] : answeredCalls
+		} catch (error: unknown) {
+			if (typeof error === "object" && error !== null && "primRpc" in error && error.primRpc === true) {
+				return error as RpcAnswer | RpcAnswer[]
 			}
-		})
-		const answeredCalls = checkRpcResult(await Promise.all(answeringCalls))
-		return answeredCalls.length === 1 ? answeredCalls[0] : answeredCalls
+			return { error: "Unknown RPC error" }
+		}
 	}
 	const prepareSend = (given: RpcAnswer | RpcAnswer[]): CommonServerResponseOptions => {
 		const body = jsonHandler.stringify(given) as string
@@ -227,7 +241,15 @@ function createServerActions(
 		const errored = statuses.filter(stat => stat === 500)
 		// NOTE: return 200:okay, 400:missing, 500:error if any call has that status
 		const status = notOkay.length > 0 ? (errored.length > 0 ? 500 : 400) : 200
-		return checkHttpLikeResponse({ body, headers, status })
+		try {
+			return checkHttpLikeResponse({ body, headers, status })
+		} catch (error: unknown) {
+			if (typeof error === "object" && error !== null && "primRpc" in error && error.primRpc === true) {
+				return { body: jsonHandler.stringify(error) as string, headers: {}, status: 500 }
+			}
+			const fallbackError = { error: "Unknown RPC error during send" }
+			return { body: jsonHandler.stringify(fallbackError) as string, headers: {}, status: 500 }
+		}
 	}
 	return { prepareCall, prepareRpc, prepareSend }
 }

--- a/libs/rpc/src/validate.ts
+++ b/libs/rpc/src/validate.ts
@@ -1,0 +1,157 @@
+import type {
+	CommonServerResponseOptions,
+	CommonServerSimpleGivenOptions,
+	RpcAnswer,
+	RpcBase,
+	RpcCall,
+} from "./interfaces"
+
+const NotGiven = Symbol("unknown")
+
+// SECTION: Validation of RPC calls and results
+
+/** Check that RPC call/result is valid object with/without an ID */
+function checkRpcBase<T extends RpcBase>(given: unknown) {
+	const givenRpc = typeof given === "object" && given !== null && given
+	if (!givenRpc) {
+		throw { error: "Invalid RPC" }
+	}
+	const id =
+		"id" in givenRpc
+			? typeof givenRpc.id === "string" || typeof givenRpc.id === "number"
+				? givenRpc.id
+				: NotGiven
+			: NotGiven
+	const toError: RpcAnswer = {} // possible error
+	const toBase: Partial<T> = {} // possible valid call
+	if (id !== NotGiven) {
+		toError.id = id
+		toBase.id = id
+	}
+	const prim = "prim" in givenRpc && typeof givenRpc.prim === "number" ? givenRpc.prim : NotGiven
+	if (prim !== NotGiven) {
+		toError.prim = prim as RpcBase["prim"]
+		toBase.prim = prim as RpcBase["prim"]
+	}
+	return { toError, toBase, givenRpc }
+}
+
+/**
+ * Check that given object is a valid RPC call
+ *
+ * @param given Possibly RPC, very possibly not
+ * @returns Valid RPC call
+ * @throws RPC response, an error
+ */
+export function checkRpcCall<T = unknown, V = T extends unknown[] ? RpcCall[] : RpcCall>(given: T): V {
+	if (Array.isArray(given)) {
+		return given.map(g => checkRpcCall(g)) as V
+	}
+	const { toError, toBase: toCall, givenRpc } = checkRpcBase<RpcCall>(given)
+	const methodValid =
+		"method" in givenRpc && typeof givenRpc.method === "string" && givenRpc.method.length > 0 && givenRpc.method
+	if (!methodValid) {
+		toError.error = "Invalid method name"
+		throw toError
+	}
+	toCall.method = methodValid
+	const argsValid = "args" in givenRpc ? (Array.isArray(givenRpc.args) ? givenRpc.args : [givenRpc.args]) : []
+	toCall.args = argsValid
+	return toCall as V
+}
+
+/**
+ * Check that given response is valid RPC response
+ *
+ * @param given The result of RPC call, expected to follow response format
+ * @returns Valid RPC result
+ * @throws RPC response, an error
+ */
+export function checkRpcResult<T = unknown, V = T extends unknown[] ? RpcAnswer[] : RpcAnswer>(given: T): V {
+	if (Array.isArray(given)) {
+		return given.map(g => checkRpcResult(g)) as V
+	}
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const { toError: _errorNotNeeded, toBase: toResult, givenRpc } = checkRpcBase<RpcAnswer>(given)
+	const result = "result" in givenRpc ? givenRpc.result : NotGiven
+	if (result !== NotGiven) {
+		toResult.result = result
+	}
+	const error = "error" in givenRpc ? givenRpc.error : NotGiven
+	if (error !== NotGiven) {
+		toResult.error = error
+	}
+	if (result === NotGiven && error === NotGiven) {
+		throw { error: "Invalid RPC result" }
+	}
+	return toResult as V
+}
+
+// !SECTION
+
+// SECTION: Validation of HTTP-like arguments/response
+export function checkHttpLikeRequest(given: unknown) {
+	const toCall: Partial<CommonServerSimpleGivenOptions> = {}
+	const givenObject = typeof given === "object" && given !== null && given
+	if (!givenObject) {
+		throw { error: "Invalid request made by method/callback handler" }
+	}
+	const url = "url" in givenObject && typeof givenObject.url === "string" && givenObject.url
+	if (url) {
+		toCall.url = url
+	}
+	const body = "body" in givenObject && typeof givenObject.body === "string" && givenObject.body
+	if (body) {
+		toCall.body = body
+	}
+	if (!toCall.url && !toCall.body) {
+		throw { error: "Either a URL or body must be given" }
+	}
+	const method = "method" in givenObject && typeof givenObject.method === "string" && givenObject.method
+	if (method) {
+		toCall.method = method
+	} else if (!toCall.body && toCall.url) {
+		toCall.method = "GET"
+	} else if (toCall.body) {
+		toCall.method = "POST"
+	} else {
+		throw { error: "Method could not be inferred from method/callback handler" }
+	}
+	return toCall as CommonServerSimpleGivenOptions
+}
+
+export function checkHttpLikeResponse(given: unknown): CommonServerResponseOptions {
+	const toRespond: Partial<CommonServerResponseOptions> = {}
+	const givenObject = typeof given === "object" && given !== null && given
+	if (!givenObject) {
+		throw { error: "Internal error while transforming response" }
+	}
+	const body = "body" in givenObject && typeof givenObject.body === "string" && givenObject.body
+	if (body) {
+		toRespond.body = body
+	} else {
+		throw { error: "Response was either not given or invalid type" }
+	}
+	const headers =
+		"headers" in givenObject &&
+		typeof givenObject.headers === "object" &&
+		Object.entries(givenObject.headers)
+			.map(([key, value]) => [key, typeof value === "string" ? value : NotGiven])
+			.filter(([_key, value]) => value !== NotGiven).length > 0
+			? (givenObject.headers as Record<string, string>)
+			: NotGiven
+	if (headers !== NotGiven) {
+		toRespond.headers = headers
+	} else {
+		toRespond.headers = {}
+	}
+	const status = "status" in givenObject && typeof givenObject.status === "number" && givenObject.status
+	if (status) {
+		toRespond.status = status
+	} else {
+		throw { error: "Response status was not set" }
+	}
+	return toRespond as CommonServerResponseOptions
+}
+
+// !SECTION


### PR DESCRIPTION
Requests/responses were vague when something went wrong while making a request to Prim+RPC server (for instance, errors would be thrown regarding method/callback handlers even though they weren't at fault but rather something else errored). Errors should now be more specific.