### PR TITLE
Client type improvements

### DIFF
--- a/.changeset/sweet-hats-smash.md
+++ b/.changeset/sweet-hats-smash.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc": patch
+---
+
+Client module generic parameter must now match module option if provided

--- a/.changeset/tame-news-cheat.md
+++ b/.changeset/tame-news-cheat.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc": patch
+---
+
+Allow list option is now typed according to module given on server

--- a/apps/frontend/src/app/prim/client.ts
+++ b/apps/frontend/src/app/prim/client.ts
@@ -7,7 +7,7 @@ import type * as moduleType from "@doseofted/prim-example"
 // const contained = JSON.parse(process.env.NEXT_PUBLIC_CONTAINED ?? "false") as boolean
 
 /** Official client to use in website */
-const client = createPrimClient<typeof moduleType>({
+const client = createPrimClient<Promise<typeof moduleType>>({
 	module: typeof window === "undefined" ? import("@doseofted/prim-example") : null,
 	endpoint: typeof window === "undefined" ? "" : window.location.origin + "/prim",
 	jsonHandler,

--- a/apps/frontend/src/app/prim/client.ts
+++ b/apps/frontend/src/app/prim/client.ts
@@ -6,7 +6,7 @@ import type * as moduleType from "@doseofted/prim-example"
 // const host = process.env.NEXT_PUBLIC_WEBSITE_HOST ?? ""
 // const contained = JSON.parse(process.env.NEXT_PUBLIC_CONTAINED ?? "false") as boolean
 
-/** Official client to us in website */
+/** Official client to use in website */
 const client = createPrimClient<typeof moduleType>({
 	module: typeof window === "undefined" ? import("@doseofted/prim-example") : null,
 	endpoint: typeof window === "undefined" ? "" : window.location.origin + "/prim",

--- a/libs/example/src/index.ts
+++ b/libs/example/src/index.ts
@@ -302,6 +302,13 @@ lookAtThisMess.somethingMadeUp = () => "Maybe we'll allow it"
 lookAtThisMess.prototype.somethingMadeUp = () => "Nope"
 lookAtThisMess.messy = { technicallyNotRpc: sayHelloAlternative, definitelyNotRpc: () => "Hi" }
 
+/** I don't mind unwrapping layers of needless properties. It makes me feel alive. */
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function wrapReturn<U>(given: U) {
+	// eslint-disable-next-line @typescript-eslint/await-thenable
+	return { response: { ["v1.2.3"]: { entity: { data: [{ attributes: { given } }] } } } }
+}
+
 /**
  *
  * @param args - Any kind of argument really

--- a/libs/rpc/src/client.test.ts
+++ b/libs/rpc/src/client.test.ts
@@ -6,7 +6,6 @@ import { describe, test, expect } from "vitest"
 import { createPrimClient, createPrimServer } from "."
 import type * as exampleClient from "@doseofted/prim-example"
 import * as exampleServer from "@doseofted/prim-example"
-import type { PrimServerOptions } from "./interfaces"
 import jsonHandler from "superjson"
 import { createPrimTestingPlugins } from "./testing"
 
@@ -42,7 +41,7 @@ describe("Prim Client can call methods with a single parameter", () => {
 		expect(result).toEqual(expected)
 	})
 	test("with local source, function that returns dynamic import", async () => {
-		const prim = createPrimClient({ module: import("@doseofted/prim-example") })
+		const prim = createPrimClient({ module: () => import("@doseofted/prim-example") })
 		const args = { greeting: "Hi", name: "Ted" }
 		const expected = module.sayHello(args)
 		const result = await prim.sayHello(args)
@@ -134,7 +133,7 @@ test("Prim Client can call allowed methods on methods", async () => {
 test("Prim Client can use alternative JSON handler", async () => {
 	const { callbackPlugin, methodPlugin, callbackHandler, methodHandler } = createPrimTestingPlugins()
 	// JSON handler is only useful with remote source (no local source test needed)
-	const commonOptions: PrimServerOptions = { jsonHandler }
+	const commonOptions = { jsonHandler }
 	createPrimServer({ ...commonOptions, module, callbackHandler, methodHandler })
 	const prim = createPrimClient<IModule>({ ...commonOptions, callbackPlugin, methodPlugin })
 	const date = new Date()

--- a/libs/rpc/src/client.ts
+++ b/libs/rpc/src/client.ts
@@ -31,6 +31,7 @@ import type {
 	PrimHttpEvents,
 	PrimHttpQueueItem,
 	BlobRecords,
+	JsonHandler,
 } from "./interfaces"
 
 /** Callback prefix */ export const CB_PREFIX = "_cb_"
@@ -53,7 +54,8 @@ export type PrimClient<ModuleType extends PrimOptions["module"]> = PromisifiedMo
  */
 export function createPrimClient<
 	ModuleType extends OptionsType["module"] = object,
-	OptionsType extends PrimOptions = PrimOptions
+	JsonHandlerType extends OptionsType["jsonHandler"] = JsonHandler,
+	OptionsType extends PrimOptions = PrimOptions<ModuleType, JsonHandlerType>
 >(options?: OptionsType): PrimClient<ModuleType> {
 	const methodPluginGiven = typeof options?.methodPlugin !== "undefined"
 	const callbackPluginGiven = typeof options?.callbackPlugin !== "undefined"

--- a/libs/rpc/src/interfaces.ts
+++ b/libs/rpc/src/interfaces.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Emitter } from "mitt"
-import type { Schema, ConditionalExcept } from "type-fest"
+import type { Schema, ConditionalExcept, PartialDeep } from "type-fest"
 
 // SECTION RPC call and result structure
 export interface RpcBase {
@@ -225,7 +225,7 @@ export interface PrimOptions<M extends object = object, J extends JsonHandler = 
 	 * If given function specifies a `.rpc` boolean property with a value of `true` then those functions do not need
 	 * to be added to the allow-list.
 	 */
-	allowList?: Schema<M, boolean>
+	allowList?: PartialDeep<Schema<M, boolean>>
 	/**
 	 * In JavaScript, functions are objects. Those objects can have methods. This means that functions can have methods.
 	 *

--- a/libs/rpc/src/interfaces.ts
+++ b/libs/rpc/src/interfaces.ts
@@ -72,7 +72,8 @@ type PromisifiedModuleDirect<
 		[Key in Keys]: ModuleGiven[Key] extends ((...args: infer A) => infer R) & object
 			? // eslint-disable-next-line @typescript-eslint/no-explicit-any
 			  R extends PromiseLike<any>
-				? ModuleGiven[Key] // NOTE: function comment is kept here but lost in function transform (need a workaround)
+				? // NOTE: function comment is kept here but lost in function transform (need a workaround)
+				  ModuleGiven[Key] & PromisifiedModuleDirect<ModuleGiven[Key], false>
 				: ((...args: A) => Promise<Awaited<R>>) & PromisifiedModuleDirect<ModuleGiven[Key], false>
 			: ModuleGiven[Key] extends object
 			? Recursive extends true
@@ -188,6 +189,8 @@ export interface PrimOptions<M extends object = object, J extends JsonHandler = 
 	 * Module to use with Prim. When a function call is made, given module will be used first, otherwise an RPC will
 	 * be made.
 	 */
+	// NOTE: instead of using `M` generic, consider using `object` for flexibility on client so dynamic imports can be
+	//supported by explicitly providing module type generic (otherwise `Promise<M>` does not align with `M` generic)
 	module?: M | null
 	/**
 	 * Provide the server URL where Prim is being used. This will be provided to the HTTP client as the endpoint

--- a/libs/rpc/src/interfaces.ts
+++ b/libs/rpc/src/interfaces.ts
@@ -189,9 +189,8 @@ export interface PrimOptions<M extends object = object, J extends JsonHandler = 
 	 * Module to use with Prim. When a function call is made, given module will be used first, otherwise an RPC will
 	 * be made.
 	 */
-	// NOTE: instead of using `M` generic, consider using `object` for flexibility on client so dynamic imports can be
-	//supported by explicitly providing module type generic (otherwise `Promise<M>` does not align with `M` generic)
-	module?: M | null
+	// NOTE: `PartialDeep` allows for partial modules to be provided while full type definitions are provided as generic
+	module?: PartialDeep<M> | null
 	/**
 	 * Provide the server URL where Prim is being used. This will be provided to the HTTP client as the endpoint
 	 * parameter.
@@ -268,7 +267,7 @@ export interface PrimOptions<M extends object = object, J extends JsonHandler = 
 	 * If given function specifies a `.rpc` boolean property with a value of `true` then those functions do not need
 	 * to be added to the allow-list.
 	 */
-	allowList?: PartialDeep<Schema<M, boolean>>
+	allowList?: PartialDeep<Schema<PromisifiedModule<M>, boolean>>
 	/**
 	 * In JavaScript, functions are objects. Those objects can have methods. This means that functions can have methods.
 	 *

--- a/libs/rpc/src/validate.ts
+++ b/libs/rpc/src/validate.ts
@@ -51,7 +51,10 @@ function checkRpcBase<T extends RpcBase>(given: unknown) {
  * @returns Valid RPC call
  * @throws RPC response, an error
  */
-export function checkRpcCall<T = unknown, V = T extends unknown[] ? RpcCall[] : RpcCall>(given: T): V {
+export function checkRpcCall<
+	T = unknown,
+	V = T extends unknown[] ? RpcCall<string, unknown[]>[] : RpcCall<string, unknown[]>
+>(given: T): V {
 	if (Array.isArray(given)) {
 		return given.map(g => checkRpcCall(g)) as V
 	}


### PR DESCRIPTION
- Fix for missing TypeDoc/JSDoc comments and generic parameters on async functions
  - Transformed synchronous functions on client don't yet retain generics/comments
  - Property comments are not yet retained but I've added an experiment to possibly fix that
- Allow list option is now typed according to module (generic parameter was not previously provided)

> **Note**: The generic parameter of the Prim+RPC client must now align with the module option. This only applies if the module option is provided. Some examples:

```typescript
import { createPrimClient } from "@doseofted/prim-rpc"
import example from "./my-example-module"

// ✅ valid
const client1 = createPrimClient<typeof example>({ module: example })
const client2 = createPrimClient<typeof example>({ module: { someFunction: example.someFunction } })
const client3 = createPrimClient<Promise<typeof example>>({ module: import("./my-example-module") })
const client4 = createPrimClient<() => Promise<typeof example>>({ module: () => import("./my-example-module") })
// ❌ invalid
const client5 = createPrimClient<typeof example>({ module: import("./my-example-module") })
const client6 = createPrimClient<typeof example>({ module: () => import("./my-example-module") })
```