### PR TITLE
Extended Options for Fetch API Plugin

### DIFF
--- a/.changeset/serious-paws-crash.md
+++ b/.changeset/serious-paws-crash.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc-plugins": patch
+---
+
+Fetch API plugin for servers now has "preprocess" option to modify Request and "postprocess" option to modify Response

--- a/libs/plugins/package.json
+++ b/libs/plugins/package.json
@@ -47,6 +47,7 @@
 		"@types/supertest": "^2.0.12",
 		"@types/ws": "^8.5.5",
 		"@vitest/web-worker": "^0.34.3",
+		"@whatwg-node/server": "^0.9.14",
 		"astro": "3.0.10",
 		"axios": "^1.5.0",
 		"express": "^4.18.2",

--- a/libs/plugins/src/server/server-fetch.test.ts
+++ b/libs/plugins/src/server/server-fetch.test.ts
@@ -1,0 +1,266 @@
+// Part of the Prim+RPC project ( https://prim.doseofted.me/ )
+// Copyright 2023 Ted Klingenberg
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @typescript-eslint/no-unsafe-member-access -- `request` doesn't have full type definitions */
+
+import { describe, test, beforeEach, expect } from "vitest"
+import request from "superwstest"
+import * as module from "@doseofted/prim-example"
+import { JsonHandler, RpcAnswer, createPrimServer } from "@doseofted/prim-rpc"
+import { primFetch } from "./server-fetch"
+import { createServerAdapter } from "@whatwg-node/server"
+import { createServer } from "node:http"
+import queryString from "query-string"
+import FormData from "form-data"
+import { Blob, File } from "node:buffer"
+import { readFileSync } from "node:fs"
+import superjson from "superjson"
+import { encode as msgPack, decode as msgUnpack } from "@msgpack/msgpack"
+
+describe("Prim+RPC can be used with Fetch API", () => {
+	const prim = createPrimServer({ module })
+	const fetch = primFetch({ prim })
+	const server = createServer(createServerAdapter(fetch))
+	beforeEach(() => {
+		server.listen(0)
+		return () => server.close()
+	})
+	const args = { greeting: "What's up", name: "Ted" }
+	const expected = { id: 1, result: module.sayHello(args) }
+	test("registered as Prim Plugin", async () => {
+		const response = await request(server)
+			.post("/prim/sayHello")
+			.send({
+				method: "sayHello",
+				args,
+				id: 1,
+			})
+			.set("accept", "application/json")
+		expect(response.headers["content-type"]).toContain("application/json")
+		expect(response.status).toEqual(200)
+		expect(response.body).toEqual(expected)
+	})
+})
+
+describe("Fetch works over GET/POST", () => {
+	const prim = createPrimServer({ module })
+	const fetch = primFetch({ prim })
+	const server = createServer(createServerAdapter(fetch))
+	beforeEach(() => {
+		server.listen(0)
+		return () => server.close()
+	})
+	const args = { greeting: "What's up", name: "Ted" }
+	const expected = { id: 1, result: module.sayHello(args) }
+	test("POST requests", async () => {
+		const response = await request(server)
+			.post("/prim")
+			.send({
+				method: "sayHello",
+				args,
+				id: 1,
+			})
+			.set("accept", "application/json")
+		expect(response.headers["content-type"]).toContain("application/json")
+		expect(response.status).toEqual(200)
+		expect(response.body).toEqual(expected)
+	})
+	test("GET requests", async () => {
+		const url = queryString.stringifyUrl({
+			url: "/prim/sayHello",
+			query: { ...args, "-": 1 },
+		})
+		const response = await request(server).get(url).send().set("accept", "application/json")
+		expect(response.headers["content-type"]).toContain("application/json")
+		expect(response.status).toEqual(200)
+		expect(response.body).toEqual(expected)
+	})
+})
+
+describe("Fetch can support binary data", () => {
+	const prim = createPrimServer({ module })
+	const fetch = primFetch({ prim })
+	const server = createServer(createServerAdapter(fetch))
+	beforeEach(() => {
+		server.listen(0)
+		return () => server.close()
+	})
+
+	test("upload a file", async () => {
+		const formData = new FormData()
+		formData.append(
+			"rpc",
+			JSON.stringify({
+				method: "uploadTheThing",
+				args: ["_bin_cool"],
+				id: 1,
+			})
+		)
+		const fileName = "hi.txt"
+		const fileContents = new Blob(["hello"], { type: "text/plain" })
+		const file = new File([fileContents], fileName)
+		formData.append("_bin_cool", await fileContents.text(), fileName)
+		const expected = { id: 1, result: module.uploadTheThing(file) }
+		const response = await request(server)
+			.post("/prim")
+			.send(formData.getBuffer())
+			.set("content-type", `multipart/form-data; boundary=${formData.getBoundary()}`)
+			.set("accept", "application/json")
+		expect(response.headers["content-type"]).toContain("application/json")
+		expect(response.status).toEqual(200)
+		expect(response.body).toEqual(expected)
+	})
+
+	test("download a file over POST", async () => {
+		const response = await request(server)
+			.post("/prim")
+			.send({
+				method: "makeItATextFile",
+				args: "Hello!",
+				id: 1,
+			})
+			.set("content-type", "application/json")
+			.set("accept", "multipart/form-data")
+		expect(response.headers["content-type"]).toContain("multipart/form-data")
+		const resultRpc = (
+			typeof response.body === "object" && "rpc" in response.body ? JSON.parse(response.body.rpc as string) : null
+		) as RpcAnswer | null
+		expect(resultRpc).not.toBeNull()
+		const binaryIdentifier = typeof resultRpc?.result === "string" ? resultRpc.result : ""
+		expect(binaryIdentifier.startsWith("_bin_")).toBe(true)
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+		const fileGiven = response.files[binaryIdentifier]
+		expect(fileGiven.originalFilename).toBe("text.txt")
+		expect(fileGiven.mimetype).toBe("text/plain")
+		const fileContents = readFileSync(fileGiven.filepath as string, { encoding: "utf-8" })
+		expect(fileContents).toBe("Hello!")
+		expect(response.status).toEqual(200)
+	})
+
+	test("download a file directly over GET", async () => {
+		const response = await request(server)
+			.get(
+				queryString.stringifyUrl({
+					url: "/prim/makeItATextFile",
+					query: { "0": "Hello!", "-": 1 },
+				})
+			)
+			.set("content-type", "application/json")
+			.set("accept", "text/plain")
+		expect(response.headers["content-type"]).toContain("text/plain")
+		expect(response.headers["content-disposition"]).toContain(`filename="text.txt"`)
+		expect(response.status).toEqual(200)
+		expect(response.text).toBe("Hello!")
+		// NOTE: if given file that wasn't text/plain, this would be a Buffer
+		// expect(response.body).toBeInstanceOf(Buffer)
+		// expect(response.body instanceof Buffer ? response.body.toString("utf-8") : "").toBe("Hello!")
+	})
+})
+
+const binaryJsonHandler: JsonHandler = {
+	parse: msgUnpack,
+	stringify: msgPack,
+	binary: true,
+	mediaType: "application/octet-stream",
+}
+
+describe("Fetch can support alternative JSON handler", () => {
+	test("with string serialization", async () => {
+		const prim = createPrimServer({ module, jsonHandler: superjson })
+		const fetch = primFetch({ prim })
+		const server = createServer(createServerAdapter(fetch))
+		server.listen(0)
+
+		const today = new Date()
+		const expected = module.whatIsDayAfter(today)
+		const response = await request(server)
+			.post("/prim")
+			.send(
+				superjson.serialize({
+					method: "whatIsDayAfter",
+					args: today,
+					id: 1,
+				})
+			)
+			.set("accept", "application/json")
+		expect(response.headers["content-type"]).toContain("application/json")
+		expect(response.status).toEqual(200)
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+		const { result }: RpcAnswer = superjson.deserialize(response.body)
+		expect(result).toBeInstanceOf(Date)
+		expect(result.valueOf()).toEqual(expected.valueOf())
+
+		server.close()
+	})
+
+	test("with binary serialization", async () => {
+		const prim = createPrimServer({ module, jsonHandler: binaryJsonHandler })
+		const fetch = primFetch({ prim })
+		const server = createServer(createServerAdapter(fetch))
+		server.listen(0)
+
+		const today = new Date()
+		const expected = module.whatIsDayAfter(today)
+		const formData = new FormData()
+		formData.append(
+			"rpc",
+			Buffer.from(
+				msgPack({
+					method: "whatIsDayAfter",
+					args: today,
+					id: 1,
+				})
+			)
+		)
+		const response = await request(server)
+			.post("/prim")
+			.send(formData.getBuffer())
+			.set("content-type", `multipart/form-data; boundary=${formData.getBoundary()}`)
+			.set("accept", "application/octet-stream")
+		expect(response.headers["content-type"]).toContain("application/octet-stream")
+		expect(response.status).toEqual(200)
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+		const { result }: RpcAnswer = msgUnpack(response.body)
+		expect(result).toBeInstanceOf(Date)
+		expect(result.valueOf()).toEqual(expected.valueOf())
+
+		server.close()
+	})
+
+	test("with binary serialization and file handling", async () => {
+		const prim = createPrimServer({ module, jsonHandler: binaryJsonHandler })
+		const fetch = primFetch({ prim })
+		const server = createServer(createServerAdapter(fetch))
+		server.listen(0)
+
+		const formData = new FormData()
+		formData.append(
+			"rpc",
+			Buffer.from(
+				msgPack({
+					method: "uploadTheThing",
+					args: ["_bin_cool"],
+					id: 1,
+				})
+			)
+		)
+		const fileName = "hi.txt"
+		const fileContents = new Blob(["hello"], { type: "text/plain" })
+		const file = new File([fileContents], fileName)
+		formData.append("_bin_cool", await fileContents.text(), fileName)
+		const expected = { id: 1, result: module.uploadTheThing(file) }
+		const response = await request(server)
+			.post("/prim")
+			.send(formData.getBuffer())
+			.set("content-type", `multipart/form-data; boundary=${formData.getBoundary()}`)
+			.set("accept", "application/octet-stream")
+		expect(response.headers["content-type"]).toContain("application/octet-stream")
+		expect(response.status).toEqual(200)
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+		const result = msgUnpack(response.body)
+		expect(result).toEqual(expected)
+
+		server.close()
+	})
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,9 @@ importers:
       '@vitest/web-worker':
         specifier: ^0.34.3
         version: 0.34.3(vitest@0.34.3)
+      '@whatwg-node/server':
+        specifier: ^0.9.14
+        version: 0.9.14
       astro:
         specifier: 3.0.10
         version: 3.0.10(@types/node@18.17.4)(sass@1.66.1)
@@ -2937,6 +2940,38 @@ packages:
       '@webassemblyjs/ast': 1.11.6
       '@xtuc/long': 4.2.2
 
+  /@whatwg-node/events@0.1.1:
+    resolution: {integrity: sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==}
+    engines: {node: '>=16.0.0'}
+    dev: true
+
+  /@whatwg-node/fetch@0.9.13:
+    resolution: {integrity: sha512-PPtMwhjtS96XROnSpowCQM85gCUG2m7AXZFw0PZlGbhzx2GK7f2iOXilfgIJ0uSlCuuGbOIzfouISkA7C4FJOw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@whatwg-node/node-fetch': 0.4.19
+      urlpattern-polyfill: 9.0.0
+    dev: true
+
+  /@whatwg-node/node-fetch@0.4.19:
+    resolution: {integrity: sha512-AW7/m2AuweAoSXmESrYQr/KBafueScNbn2iNO0u6xFr2JZdPmYsSm5yvAXYk6yDLv+eDmSSKrf7JnFZ0CsJIdA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@whatwg-node/events': 0.1.1
+      busboy: 1.6.0
+      fast-querystring: 1.1.2
+      fast-url-parser: 1.1.3
+      tslib: 2.6.2
+    dev: true
+
+  /@whatwg-node/server@0.9.14:
+    resolution: {integrity: sha512-I8TT0NoCP+xThLBuGlU6dgq5wpExkphNMo2geZwQW0vAmEPtc3MNMZMIYqg5GyNmpv5Nf7fnxb8tVOIHbDvuDA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@whatwg-node/fetch': 0.9.13
+      tslib: 2.6.2
+    dev: true
+
   /@xobotyi/scrollbar-width@1.9.5:
     resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
     dev: false
@@ -5040,6 +5075,12 @@ packages:
 
   /fast-uri@2.2.0:
     resolution: {integrity: sha512-cIusKBIt/R/oI6z/1nyfe2FvGKVTohVRfvkOhvx0nCEW+xf5NoCXjAHcWp93uOUBchzYcsvPlrapAdX1uW+YGg==}
+
+  /fast-url-parser@1.1.3:
+    resolution: {integrity: sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==}
+    dependencies:
+      punycode: 1.4.1
+    dev: true
 
   /fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -8162,6 +8203,10 @@ packages:
     dev: true
     optional: true
 
+  /punycode@1.4.1:
+    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
+    dev: true
+
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
@@ -10376,6 +10421,10 @@ packages:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+    dev: true
+
+  /urlpattern-polyfill@9.0.0:
+    resolution: {integrity: sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==}
     dev: true
 
   /use-immer@0.9.0(immer@10.0.2)(react@18.2.0):


### PR DESCRIPTION
The Fetch API doesn't have the same options available in many server frameworks, like connect middleware or plugins. Instead, changes are made directly to the Request/Response objects. This PR will add two new options, "preprocess" to modify the Request before being given to Prim+RPC and "postprocess" to manipulate the Response created by Prim+RPC.

This will allow headers to be set (specifically CORS and CSP) without explicitly providing limited "options" for the plugin.