### PR TITLE
Handle Promises In RPC Result

### DIFF
--- a/libs/rpc/src/client.ts
+++ b/libs/rpc/src/client.ts
@@ -36,6 +36,7 @@ import type {
 
 /** Callback prefix */ export const CB_PREFIX = "_cb_"
 /** Binary prefix (Blob/File) */ export const BLOB_PREFIX = "_bin_"
+/** Promise prefix */ export const PROMISE_PREFIX = "_prom_"
 
 export type PrimClient<ModuleType extends PrimOptions["module"]> = PromisifiedModule<ModuleType>
 // export interface PrimClient<ModuleType extends PrimOptions["module"]> {

--- a/libs/rpc/src/extract.ts
+++ b/libs/rpc/src/extract.ts
@@ -1,0 +1,104 @@
+import { nanoid } from "nanoid"
+import type { UniqueTypePrefix } from "./interfaces"
+
+/**
+ * Extract given type `T` from any given argument (object/array/primitive) to form `Record<string, T>`.
+ * This is not recursive due to potential performance issues with deeply nested large objects.
+ * However, recursion to a limited depth may be added in future if necessary or useful.
+ *
+ * This can be undone by `mergeGivenData()`.
+ *
+ * @param given - The given argument to extract from
+ * @param extractMatches - A function that matches the extracted type against argument and returns that back only if test is passed
+ * @param prefix - A prefix to use for the identifier in returned record
+ * @returns A tuple of the given argument with transformations and a record of extracted data
+ */
+export function extractGivenData<Extract = unknown>(
+	given: unknown,
+	extractMatches: (given: unknown) => Extract,
+	prefix: UniqueTypePrefix
+): [given: unknown, extracted: Record<string, Exclude<Extract, false>>] {
+	const extractedRecord: Record<string, Exclude<Extract, false>> = {}
+	const extracted = extractMatches(given)
+	// extracted type was given directly
+	if (extracted) {
+		const identifier = [prefix, nanoid()].join("")
+		extractedRecord[identifier] = extracted as Exclude<Extract, false>
+		return [identifier, extractedRecord]
+	}
+	// extracted type may possibly be inside of an object
+	if (typeof given === "object") {
+		for (const [key, val] of Object.entries(given)) {
+			const valBinary = extractMatches(val)
+			if (valBinary) {
+				const binaryIdentifier = [prefix, nanoid()].join("")
+				given[key] = binaryIdentifier
+				extractedRecord[binaryIdentifier] = valBinary as Exclude<Extract, false>
+			} else if (Array.isArray(val)) {
+				// maybe multiple extracted types were given
+				const [replacedVal, moreBlobs] = extractGivenData(val, extractMatches, prefix)
+				given[key] = replacedVal
+				for (const [blobKey, blob] of Object.entries(moreBlobs)) {
+					extractedRecord[blobKey] = blob
+				}
+			}
+		}
+		if (Object.keys(extractedRecord).length > 0) {
+			return [given, extractedRecord]
+		}
+	}
+	// extracted type may be inside of an array
+	if (Array.isArray(given)) {
+		const replaced = given.map(val => {
+			const valBinary = extractMatches(val)
+			if (valBinary) {
+				const binaryIdentifier = [prefix, nanoid()].join("")
+				extractedRecord[binaryIdentifier] = valBinary as Exclude<Extract, false>
+				return binaryIdentifier
+			}
+			return val as unknown
+		})
+		if (Object.keys(extractedRecord).length > 0) {
+			return [replaced, extractedRecord]
+		}
+	}
+	return [given, extractedRecord]
+}
+
+/**
+ * Given some object transformed with `extractGivenData()`, merge the extracted data back into the object.
+ *
+ * @param given The given object to merge extracted data back into
+ * @param extracted The extracted objects need to become merged back into the given object
+ * @param prefix The prefix used for the identifier in the extracted record
+ * @returns The merged object
+ */
+export function mergeGivenData<Extract = unknown>(
+	given: unknown,
+	extracted: Record<string, Extract>,
+	prefix: UniqueTypePrefix
+): unknown {
+	if (typeof given === "string" && given.startsWith(prefix)) {
+		return extracted[given] ?? given
+	}
+	if (typeof given === "object") {
+		for (const [key, val] of Object.entries(given)) {
+			if (typeof val === "string" && val.startsWith(prefix)) {
+				given[key] = extracted[val] ?? val
+			} else if (Array.isArray(val)) {
+				const newVal = mergeGivenData(val, extracted, prefix)
+				given[key] = newVal
+			}
+		}
+		return given as unknown
+	}
+	if (Array.isArray(given)) {
+		return given.map(given => {
+			if (typeof given === "string" && given.startsWith(prefix)) {
+				return extracted[given] ?? given
+			}
+			return given as unknown
+		})
+	}
+	return given
+}

--- a/libs/rpc/src/interfaces.ts
+++ b/libs/rpc/src/interfaces.ts
@@ -20,6 +20,16 @@ export interface RpcAnswer<Result = unknown, Error = unknown> extends RpcBase {
 	result?: Result
 	error?: Error
 }
+
+export enum UniquePrefixName {
+	/** Prefix for binary data */
+	Binary = "bin",
+	/** Prefix for callbacks */
+	Callback = "cb",
+	/** Prefix for promises */
+	Promise = "prom",
+}
+export type UniqueTypePrefix = `_${UniquePrefixName}_${string}`
 // !SECTION
 
 // SECTION HTTP/WebSocket events

--- a/libs/rpc/src/promises.ts
+++ b/libs/rpc/src/promises.ts
@@ -1,0 +1,14 @@
+import { PROMISE_PREFIX } from "./client"
+import { extractGivenData, mergeGivenData } from "./extract"
+
+function isPromise(given: unknown) {
+	return given instanceof Promise ? given : false
+}
+
+export function extractPromiseData(given: unknown): [given: unknown, promises: Record<string, Promise<unknown>>] {
+	return extractGivenData(given, isPromise, PROMISE_PREFIX)
+}
+
+export function mergePromiseData(given: unknown, promises: Record<string, Promise<unknown>>): unknown {
+	return mergeGivenData(given, promises, PROMISE_PREFIX)
+}


### PR DESCRIPTION
When returning a result from a function, today it's generally expected in Prim+RPC that all promises contained in the result have already been resolved and those promise wrappers have been removed.

However, when working with multiple promises, it may be more beneficial to the client to return quickly with multiple unresolved promises and simply resolve each promise individually (for instance when rendering data to a UI where data should be displayed as soon as it becomes available).

This PR adds Promises as a new "serializable" type, like blobs or callbacks. It will behave very similarly to callbacks.

- Promises should be handled only with the callback plugin since the method plugin has a request/response format that is incompatible with multiple promises (multiple responses)
- Promises will become extracted from RPC into new promises object (similar to blobs).
- Over WebSocket connections, it will be sent as a separate message. If a callback plugin in the future supports HTTP directly, it would either use FormData or potentially newline-delimited JSON over SSE (but probably FormData since file uploads may also be used in same function call).