### PR TITLE
Improved client types

### DIFF
--- a/.changeset/good-points-bathe.md
+++ b/.changeset/good-points-bathe.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc": patch
+---
+
+Improved type support on client for passing form events to a function (transformed by server)

--- a/.changeset/neat-houses-tickle.md
+++ b/.changeset/neat-houses-tickle.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc": patch
+---
+
+All type definitions for functions are transformed client-side because `this` argument is not needed on client

--- a/libs/plugins/src/server/server-fetch.ts
+++ b/libs/plugins/src/server/server-fetch.ts
@@ -7,7 +7,7 @@ import { BlobRecords, PrimServerEvents } from "@doseofted/prim-rpc"
 interface PrimRequestOptions {
 	prim: PrimServerEvents
 	/** Transform a request into an object to be passed to your function's `this` context */
-	contextTransform?: (request: Request, response?: ResponseInit & { headers: Headers }) => unknown
+	contextTransform?: (request: Request, response: ResponseInit & { headers: Headers }) => unknown
 	/** Process given Request before handing it off to this plugin */
 	preprocess?: (request: Request) => Request | Promise<Request | undefined> | void
 	/** Process Prim+RPC generated Response before sending it back to your server */

--- a/libs/rpc/src/interfaces.ts
+++ b/libs/rpc/src/interfaces.ts
@@ -60,6 +60,12 @@ interface PrimWebSocketFunctionEvents {
 // SECTION Client options
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+type FunctionAndForm<Args extends any[], Result> = {
+	(...args: Args): Result
+	(formLike: SubmitEvent | FormData | HTMLFormElement): Result
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyFunction = (...args: any[]) => any
 // NOTE: consider condition of checking `.rpc` property on function (but also remember that it may be in allow list)
 type PromisifiedModuleDirect<
@@ -69,11 +75,7 @@ type PromisifiedModuleDirect<
 > = ConditionalExcept<
 	{
 		[Key in Keys]: ModuleGiven[Key] extends ((...args: infer A) => infer R) & object
-			? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-			  R extends PromiseLike<any>
-				? // NOTE: function comment is kept here but lost in function transform (need a workaround)
-				  ModuleGiven[Key] & PromisifiedModuleDirect<ModuleGiven[Key], false>
-				: ((...args: A) => Promise<Awaited<R>>) & PromisifiedModuleDirect<ModuleGiven[Key], false>
+			? ((...args: A) => Promise<Awaited<R>>) & PromisifiedModuleDirect<ModuleGiven[Key], false>
 			: ModuleGiven[Key] extends object
 			? Recursive extends true
 				? PromisifiedModuleDirect<ModuleGiven[Key], true>

--- a/libs/rpc/src/interfaces.ts
+++ b/libs/rpc/src/interfaces.ts
@@ -75,7 +75,7 @@ type PromisifiedModuleDirect<
 > = ConditionalExcept<
 	{
 		[Key in Keys]: ModuleGiven[Key] extends ((...args: infer A) => infer R) & object
-			? ((...args: A) => Promise<Awaited<R>>) & PromisifiedModuleDirect<ModuleGiven[Key], false>
+			? FunctionAndForm<A, Promise<Awaited<R>>> & PromisifiedModuleDirect<ModuleGiven[Key], false>
 			: ModuleGiven[Key] extends object
 			? Recursive extends true
 				? PromisifiedModuleDirect<ModuleGiven[Key], true>


### PR DESCRIPTION
It's even easier to use Prim+RPC with TypeScript:

- Function types on client are overloaded to allow easy usage with forms       
   - Client already supports forms but now types reflect that
   - Supports types including `FormData`, `HTMLFormElement`, and `SubmitEvent`
- Function context (`this`) is removed from client-side functions since it can't be utilized on client
- Improved Fetch plugin's `contextTransform` type to reflect that `res` parameter is always provided