### PR TITLE
Support new RPC keyword for idempotency

### DIFF
--- a/.changeset/tender-timers-pretend.md
+++ b/.changeset/tender-timers-pretend.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc": minor
+---
+
+.methodsOnMethods option now requires an key/value object where the key is the method-on-method name and the value is either `true` or `"idempotent"` (similar to .allowList option)

--- a/.changeset/wet-boxes-search.md
+++ b/.changeset/wet-boxes-search.md
@@ -1,0 +1,5 @@
+---
+"@doseofted/prim-rpc": minor
+---
+
+RPC can no longer be made by GET requests by default: introduced new keyword for function's `.rpc` property named "idempotent" that, when used with HTTP plugins, allows RPC over GET requests

--- a/apps/documentation/src/content/docs/learn/advanced.mdx
+++ b/apps/documentation/src/content/docs/learn/advanced.mdx
@@ -95,7 +95,7 @@ export async function markdownToHtml(markdownFile: File | string) {
 	const html = micromark(markdown)
 	return new File([html], "snippet.html", { type: "text/html" })
 }
-markdownToHtml.rpc = true
+markdownToHtml.rpc = "idempotent"
 ```
 
 </CodeFile>

--- a/apps/documentation/src/content/docs/learn/security.mdx
+++ b/apps/documentation/src/content/docs/learn/security.mdx
@@ -98,6 +98,49 @@ type SayHelloParams = Input<typeof sayHello.params>
 Now we can be certain that not only will this function's arguments be validated but functions added in the future will
 require validation through the `params` property.
 
+## Limit RPC Access
+
+By default, when Prim+RPC is used over a network, it only accepts requests over a POST request. However, you can still
+make an RPC with a GET request using the special keyword `"idempotent"`.
+
+However, you should take caution when doing so. We can demonstrate with an example. This is an idempotent function:
+
+<CodeFile filename="server/module.ts">
+
+```typescript
+export function add(x: number, y: number) {
+	return x + y
+}
+add.rpc = "idempotent"
+```
+
+</CodeFile>
+
+No matter how many times that we call this function, we will always get the same result. This can be exposed over a URL
+(with a GET request) because simply visiting that URL won't change the state of the server. Here's a bad example:
+
+<CodeFile filename="server/module.ts">
+
+```typescript
+const x = 0
+
+export function add(y: number) {
+	return x + y
+}
+// NOTE: the property below should be set to `true` instead
+add.rpc = "idempotent"
+```
+
+</CodeFile>
+
+If we expose this function over a URL, then visiting that URL will change the state of the server which may not be
+intended.
+
+It's also important to note that GET requests are often logged so functions that use the `"idempotent"` keyword should
+**never have sensitive arguments passed** to them. All functions where `.rpc = true` will be POST requests and cannot be
+accessed with a GET request. All functions where `.rpc = "idempotent"` may be accessed from either a GET or POST
+request.
+
 ## Selectively Import
 
 Prim+RPC is very selective about what gets exposed from the server. Functions (and functions only) must be passed to the

--- a/apps/documentation/src/content/docs/learn/setup.mdx
+++ b/apps/documentation/src/content/docs/learn/setup.mdx
@@ -273,20 +273,50 @@ export type Module = typeof module
 
 </CodeFile>
 
-We can now make requests to the server! We haven't set up the client yet but we can still try it out. Requests in
-Prim+RPC are typically made over POST but for demo's sake:
+We can now make requests to the server! We haven't set up the client yet but we can still try it out from the command line:
+
+<CodeFile>
+
+```zsh
+curl \
+	--request POST \
+	--header "Content-Type: application/json" \
+	--data '{ "method": "sayHello", "args": ["Backend", "Terminal"] }' \
+	"http://localhost:3001/prim"
+# {"result":"Backend, meet Terminal."}
+```
+
+</CodeFile>
+
+In fact, we could even call this function over a GET request. We just need to modify out `.rpc` property to use a
+special keyword: `"idempotent"`
+
+<CodeFile filename="server/module.ts">
+
+```typescript /"idempotent"/
+export function sayHello(x = "Backend", y = "Frontend") {
+	return `${x}, meet ${y}.`
+}
+sayHello.rpc = "idempotent"
+```
+
+</CodeFile>
+
+This will signal to Prim+RPC that it's safe to call from a URL. Now we can make a GET request to this function
+or paste the link into a web browser:
 
 <CodeFile>
 
 ```zsh
 curl "http://localhost:3001/prim/sayHello?0=Backend&1=Terminal"
+# {"result":"Backend, meet Terminal."}
 ```
 
 </CodeFile>
 
-We'll be calling this function from a web browser next. This means that we'll need to
-[implement CORS](https://developer.mozilla.org/en-US/docs/Glossary/CORS) so that the client is allowed to call the
-server. We can configure this in the Fetch handler's options:
+Of course, this is not the primary way we'll be using Prim+RPC: we'll be setting up the client next. This means that
+we'll need to [implement CORS](https://developer.mozilla.org/en-US/docs/Glossary/CORS) so that the client is allowed to
+call the server. We can configure this in the Fetch handler's options:
 
 <CodeFile filename="server/index.ts">
 

--- a/apps/documentation/src/content/docs/reference/config.mdx
+++ b/apps/documentation/src/content/docs/reference/config.mdx
@@ -311,7 +311,7 @@ hello.documentation = () => "I say hello"
 
 createPrimServer({
 	module: { hello },
-	methodsOnMethods: ["documentation"],
+	methodsOnMethods: { documentation: true },
 })
 ```
 

--- a/apps/documentation/src/content/docs/reference/config.mdx
+++ b/apps/documentation/src/content/docs/reference/config.mdx
@@ -64,6 +64,10 @@ one of two ways:
 - Define a `.rpc` property on each of your functions with a value of `true`
 - Or add your function to the [Allow List](#-allow-list) option
 
+If your function may be accessed by visiting a URL, you may set the `.rpc` option to `"idempotent"`. If an HTTP method
+handler has been configured, this will allow the function to be accessed by a GET request (by default, only POST
+requests are allowed with a method handler).
+
 ## <Icon class="w-6 h-6" name="ph:brackets-curly-bold"/> HTTP Endpoint
 
 <DataListOptions />

--- a/apps/documentation/src/content/docs/reference/create.mdx
+++ b/apps/documentation/src/content/docs/reference/create.mdx
@@ -172,6 +172,8 @@ Prim+RPC can understand.
 
 - `server.prepareCall()` takes common server options and transforms it into an RPC object.
 - `server.prepareRpc()` takes result of `server.prepareCall()` and creates an RPC result object from the function call.
+  It also takes an optional HTTP method argument if used over a network (if not used on a network, set this argument to
+  `false`).
 - `server.prepareSend()` takes the result of `server.prepareRpc()` and serializes it into common server response
   options.
 - `server.call()` is a shortcut that calls all of the above methods in order. This is useful in HTTP/WebSocket server

--- a/apps/documentation/src/content/plugins/server/express.mdx
+++ b/apps/documentation/src/content/plugins/server/express.mdx
@@ -20,7 +20,7 @@ The Prim+RPC server can be configured with Express. First, create some module to
 export function hello() {
 	return "Hi from Prim+RPC!"
 }
-hello.rpc = true
+hello.rpc = "idempotent"
 
 export default hello
 ```
@@ -75,7 +75,7 @@ Now we can test this out with a simple call from the command line:
 <CodeFile>
 
 ```zsh
-curl --request GET --url "http://localhost:3000/prim"
+curl "http://localhost:3000/prim"
 ```
 
 </CodeFile>

--- a/apps/documentation/src/content/plugins/server/fastify.mdx
+++ b/apps/documentation/src/content/plugins/server/fastify.mdx
@@ -20,7 +20,7 @@ The Prim+RPC server can be configured with Fastify. First, create some module to
 export function hello() {
 	return "Hi from Prim+RPC!"
 }
-hello.rpc = true
+hello.rpc = "idempotent"
 
 export default hello
 ```
@@ -75,7 +75,7 @@ Now we can test this out with a simple call from the command line:
 <CodeFile>
 
 ```zsh
-curl --request GET --url "http://localhost:3000/prim"
+curl "http://localhost:3000/prim"
 ```
 
 </CodeFile>

--- a/apps/documentation/src/content/plugins/server/h3.mdx
+++ b/apps/documentation/src/content/plugins/server/h3.mdx
@@ -28,7 +28,7 @@ naming patterns. We'll cover all frameworks separately to reduce confusion.
 export function hello() {
 	return "Hi from Prim+RPC!"
 }
-hello.rpc = true
+hello.rpc = "idempotent"
 
 export default hello
 ```
@@ -91,7 +91,7 @@ We can test this out by issuing a new request from the command line:
 <CodeFile>
 
 ```zsh
-curl --request GET --url "http://localhost:3000/prim"
+curl "http://localhost:3000/prim"
 ```
 
 </CodeFile>
@@ -137,7 +137,7 @@ We can test this out by issuing a new request from the command line (change port
 <CodeFile>
 
 ```zsh
-curl --request GET --url "http://localhost:3000/prim"
+curl "http://localhost:3000/prim"
 ```
 
 </CodeFile>

--- a/apps/documentation/src/content/plugins/server/hono.mdx
+++ b/apps/documentation/src/content/plugins/server/hono.mdx
@@ -20,7 +20,7 @@ Prim+RPC supports Hono and is very easy to set up. First, let's set up our funct
 export function hello() {
 	return "Hi from Prim+RPC!"
 }
-hello.rpc = true
+hello.rpc = "idempotent"
 
 export default hello
 ```
@@ -56,7 +56,7 @@ to be changed):
 <CodeFile>
 
 ```zsh
-curl --request GET --url "http://localhost:3000/prim"
+curl "http://localhost:3000/prim"
 ```
 
 </CodeFile>

--- a/apps/documentation/src/content/plugins/server/server-fetch.mdx
+++ b/apps/documentation/src/content/plugins/server/server-fetch.mdx
@@ -35,7 +35,7 @@ First, you'll need some module with functions that you'd like to expose to the c
 export function hello() {
 	return "Hi from Prim+RPC!"
 }
-hello.rpc = true
+hello.rpc = "idempotent"
 
 export default hello
 ```
@@ -125,7 +125,7 @@ your Prim+RPC server. You can test it out like so:
 
 ```zsh
 # Remember to change the address depending on your server
-curl --request GET --url "http://localhost:3000/prim"
+curl "http://localhost:3000/prim"
 ```
 
 </CodeFile>

--- a/libs/example/src/index.ts
+++ b/libs/example/src/index.ts
@@ -68,7 +68,7 @@ export function sayHello(options?: Greeting) {
 	const { greeting, name } = options ?? {}
 	return `${greeting ?? "Hello"} ${name ?? "you"}!`
 }
-sayHello.rpc = true
+sayHello.rpc = "idempotent"
 
 /**
  * An alternative to `sayHello` that uses positional arguments.
@@ -291,7 +291,7 @@ export async function makeItATextFile(text: string) {
 	const { File } = await import("node:buffer")
 	return new File([text], "text.txt", { type: "text/plain" })
 }
-makeItATextFile.rpc = true
+makeItATextFile.rpc = "idempotent" // I mean in a way, server resources aren't changed, maybe I need another keyword
 
 /**
  * Make an introduction.

--- a/libs/plugins/src/server/hono.test.ts
+++ b/libs/plugins/src/server/hono.test.ts
@@ -35,13 +35,14 @@ describe("Hono plugin is functional as Prim Plugin", () => {
 	const expected = { id: 1, result: module.sayHello(args) }
 	test("registered as Prim Plugin", async () => {
 		const response = await request(server)
-			.post("/prim/sayHello")
+			.post("/prim")
 			.send({
 				method: "sayHello",
 				args,
 				id: 1,
 			})
 			.set("accept", "application/json")
+		console.log(response.body)
 		expect(response.headers["content-type"]).toContain("application/json")
 		expect(response.status).toEqual(200)
 		expect(response.body).toEqual(expected)

--- a/libs/plugins/src/server/hono.test.ts
+++ b/libs/plugins/src/server/hono.test.ts
@@ -42,7 +42,6 @@ describe("Hono plugin is functional as Prim Plugin", () => {
 				id: 1,
 			})
 			.set("accept", "application/json")
-		console.log(response.body)
 		expect(response.headers["content-type"]).toContain("application/json")
 		expect(response.status).toEqual(200)
 		expect(response.body).toEqual(expected)

--- a/libs/plugins/src/server/hono.ts
+++ b/libs/plugins/src/server/hono.ts
@@ -43,9 +43,7 @@ export function honoPrimRpc(options: PrimHonoPluginOptions) {
 			body = await req.text()
 		}
 		const server = prim.server()
-		console.log({ body, url, method, blobs })
 		const result = await server.call({ body, url, method, blobs }, contextTransform(context))
-		console.log({ result })
 		const hasBinary = ["application/octet-stream", "multipart/form-data"].includes(result.headers["content-type"])
 		let firstFile = { name: "", blob: null as Blob | null, type: "application/octet-stream" }
 		const blobEntries = Object.entries(result.blobs)

--- a/libs/plugins/src/server/hono.ts
+++ b/libs/plugins/src/server/hono.ts
@@ -33,6 +33,7 @@ export function honoPrimRpc(options: PrimHonoPluginOptions) {
 			const formData = await req.formData()
 			for (const [key, value] of formData) {
 				if (key === "rpc") {
+					// eslint-disable-next-line @typescript-eslint/no-base-to-string
 					body = value instanceof Blob && jsonHandler.binary ? await value.arrayBuffer() : value.toString()
 				} else if (key.startsWith("_bin_") && value instanceof Blob) {
 					blobs[key] = value
@@ -42,7 +43,9 @@ export function honoPrimRpc(options: PrimHonoPluginOptions) {
 			body = await req.text()
 		}
 		const server = prim.server()
+		console.log({ body, url, method, blobs })
 		const result = await server.call({ body, url, method, blobs }, contextTransform(context))
+		console.log({ result })
 		const hasBinary = ["application/octet-stream", "multipart/form-data"].includes(result.headers["content-type"])
 		let firstFile = { name: "", blob: null as Blob | null, type: "application/octet-stream" }
 		const blobEntries = Object.entries(result.blobs)

--- a/libs/rpc/src/allow.ts
+++ b/libs/rpc/src/allow.ts
@@ -1,0 +1,41 @@
+/**
+ * Check that a function can be executed as RPC based on the given `.rpc` property. The `.rpc` property can be retrieved
+ * from a function by calling `getFunctionRpcProperty()`.
+ *
+ * This compares the given `rpcSpecifier` with given request options (currently, only the `httpMethod`).
+ *
+ * By default, all requests sent over a network to Prim+RPC are POST-like:
+ *
+ * - When `.rpc` is `true`, the HTTP method must be `"POST"` when applicable or `false` (inapplicable, i.e. IPC)
+ * - When `.rpc` is `"idempotent"` (a special keyword), the HTTP method may also be `"GET"`
+ *
+ * @param rpcSpecifier The value of a function's `.rpc` property
+ * @param httpMethod The optional HTTP method used in a request
+ * @returns whether function can be called based on given RPC property and given request options
+ */
+export function checkRpcIdentifier(rpcSpecifier: string | boolean, httpMethod: string | false) {
+	const postMethodAllowed =
+		typeof rpcSpecifier === "boolean" && rpcSpecifier && (httpMethod === "POST" || httpMethod === false)
+	if (postMethodAllowed) return postMethodAllowed
+	const getMethodAllowed =
+		typeof rpcSpecifier === "string" &&
+		rpcSpecifier === "idempotent" &&
+		(typeof httpMethod === "string" ? ["GET", "POST"].includes(httpMethod) : httpMethod === false)
+	if (getMethodAllowed) return getMethodAllowed
+	return false
+}
+
+/**
+ * Given a function, grab the `.rpc` property. **This does not check that the `.rpc` property is valid** only that it
+ * exists and it is the expected scalar type.
+ *
+ * @param possibleFunction A possible function given on a module
+ */
+export function getFunctionRpcProperty(possibleFunction?: unknown) {
+	return (
+		typeof possibleFunction === "function" &&
+		"rpc" in possibleFunction &&
+		(typeof possibleFunction.rpc === "string" || typeof possibleFunction.rpc === "boolean") &&
+		possibleFunction.rpc
+	)
+}

--- a/libs/rpc/src/client.test.ts
+++ b/libs/rpc/src/client.test.ts
@@ -331,7 +331,6 @@ test("Prim Client knows when an experimental flag is disabled", async () => {
 	const expected = module.promisesUnwrapped(10)
 	// FIXME: callback is needed to use callback plugin (otherwise method plugin is used which doesn't support promises)
 	const result = await prim.promisesUnwrapped(10, () => "uh oh")
-	console.log("expected", result)
 	expect(result.hi).toEqual(expected.hi)
 	expect(result.date).toBeInstanceOf(Date)
 	// NOTE: without promise support (flag disabled), promises in the result are stringified into empty object

--- a/libs/rpc/src/client.test.ts
+++ b/libs/rpc/src/client.test.ts
@@ -83,11 +83,11 @@ describe("Prim Client cannot call non-RPC", () => {
 		const functionCall = () => prim.definitelyNotRpc()
 		await expect(functionCall()).rejects.toThrow("Method was not allowed")
 	})
-	test("with method on method that's not allowed", async () => {
+	test("with methods on methods that are not allowed", async () => {
 		const { callbackPlugin, methodPlugin, callbackHandler, methodHandler } = createPrimTestingPlugins()
 		// We pass some made-up method-on-method name because if none are given then no methods on methods are allowed
 		// and I need to test to make sure that the allow list is working
-		createPrimServer({ module, callbackHandler, methodHandler, methodsOnMethods: ["somethingMadeUp"] })
+		createPrimServer({ module, callbackHandler, methodHandler, methodsOnMethods: { somethingMadeUp: true } })
 		const prim = createPrimClient<IModule>({ callbackPlugin, methodPlugin })
 		// below is not valid because it's in Prim RPC's deny list
 		const functionCall1 = () => prim.greetings.toString()
@@ -95,6 +95,9 @@ describe("Prim Client cannot call non-RPC", () => {
 		// this is not valid because, while the method-on-method is allowed, it's called on the prototype
 		const functionCall2 = () => prim.lookAtThisMess.prototype.somethingMadeUp()
 		await expect(functionCall2()).rejects.toThrow("Method was not valid")
+		// this is valid because the method-on-method is allowed and is not defined on the prototype
+		const functionCall5 = () => prim.lookAtThisMess.somethingMadeUp()
+		await expect(functionCall5()).resolves.toEqual("Maybe we'll allow it")
 		// below is not valid because "docs" method-on-method is not in the allowed list
 		const functionCall3 = () => prim.lookAtThisMess.docs()
 		await expect(functionCall3()).rejects.toThrow("Method on method was not allowed")
@@ -126,7 +129,7 @@ describe("Prim Client can call methods with positional parameters", () => {
 test("Prim Client can call allowed methods on methods", async () => {
 	const { callbackPlugin, methodPlugin, callbackHandler, methodHandler } = createPrimTestingPlugins()
 	// JSON handler is only useful with remote source (no local source test needed)
-	createPrimServer({ module, callbackHandler, methodHandler, methodsOnMethods: ["docs"] })
+	createPrimServer({ module, callbackHandler, methodHandler, methodsOnMethods: { docs: true } })
 	const prim = createPrimClient<IModule>({ callbackPlugin, methodPlugin })
 	const expected = module.lookAtThisMess.docs()
 	const result = await prim.lookAtThisMess.docs()

--- a/libs/rpc/src/interfaces.ts
+++ b/libs/rpc/src/interfaces.ts
@@ -511,7 +511,11 @@ export interface PrimServerActionsBase<Context = unknown> {
 	 * Step 2: Using the result of `.prepareCall()`, use the RPC to get a result from Prim.
 	 * See `.prepareSend()` for next step.
 	 */
-	prepareRpc: (given: RpcCall | RpcCall[], context?: Context) => Promise<RpcAnswer | RpcAnswer[]>
+	prepareRpc: (
+		given: RpcCall | RpcCall[],
+		context: Context,
+		httpMethod: string | false
+	) => Promise<RpcAnswer | RpcAnswer[]>
 	/**
 	 * Step 3: Using the result of `.rpc()`, prepare the result to be sent with the server framework.
 	 */

--- a/libs/rpc/src/interfaces.ts
+++ b/libs/rpc/src/interfaces.ts
@@ -341,7 +341,7 @@ export interface PrimOptions<M extends PossibleModule = object, J extends JsonHa
 	 * In JavaScript, functions are objects. Those objects can have methods. This means that functions can have methods.
 	 *
 	 * By default, methods on functions are not allowed as RPC. You may optionally allow some methods by specifying
-	 * a list of those names in this option. For instance, if this option is set to `["docs"]` then that means you
+	 * a key/value pair of those names in this option. For instance, if this option is set to `{ docs: true }` then that means you
 	 * could call `sayHello.docs()` where `sayHello` is another function.
 	 */
 	methodsOnMethods?: { [key: string]: true | "idempotent" }

--- a/libs/rpc/src/interfaces.ts
+++ b/libs/rpc/src/interfaces.ts
@@ -336,7 +336,7 @@ export interface PrimOptions<M extends PossibleModule = object, J extends JsonHa
 	 * If given function specifies a `.rpc` boolean property with a value of `true` then those functions do not need
 	 * to be added to the allow-list.
 	 */
-	allowList?: PartialDeep<Schema<PromisifiedModule<M>, boolean>>
+	allowList?: PartialDeep<Schema<PromisifiedModule<M>, boolean | "idempotent">>
 	/**
 	 * In JavaScript, functions are objects. Those objects can have methods. This means that functions can have methods.
 	 *
@@ -344,7 +344,7 @@ export interface PrimOptions<M extends PossibleModule = object, J extends JsonHa
 	 * a list of those names in this option. For instance, if this option is set to `["docs"]` then that means you
 	 * could call `sayHello.docs()` where `sayHello` is another function.
 	 */
-	methodsOnMethods?: string[]
+	methodsOnMethods?: { [key: string]: true | "idempotent" }
 	/**
 	 * Whether Errors should be serialized before sending from the server and deserialized when received on the client.
 	 * The default is `true` unless a custom JSON handler is set. You may set this option explicitly to always use your

--- a/libs/rpc/src/options.ts
+++ b/libs/rpc/src/options.ts
@@ -57,7 +57,7 @@ const createBaseClientOptions = (server = false): PrimOptions => ({
 	// a developer may specify an allow list if there's not direct access to the module
 	allowList: {},
 	// by default, only functions provided can be called (not their methods, if any are defined)
-	methodsOnMethods: [],
+	methodsOnMethods: {},
 	// Stringified Errors with the default JSON handler are empty objects
 	// Empty errors could be a source of confusion if an end-user doesn't receive an error on the client when one is
 	// thrown from the server so set this to `true` (if presets are used, this may be set to `false` for

--- a/libs/rpc/src/server.ts
+++ b/libs/rpc/src/server.ts
@@ -180,7 +180,6 @@ function createServerActions(
 								}
 								const directPreviousPath = getProperty(givenModule, methodExpanded.slice(0, -1)) as unknown
 								const rpcSpecifierForMethodOnMethod = serverOptions.methodsOnMethods[methodExpanded.slice(-1)[0]]
-								console.log({ rpcSpecifierForMethodOnMethod })
 								if (typeof directPreviousPath === "function" && !rpcSpecifierForMethodOnMethod) {
 									const rpcAllowedForMethodOnMethod = checkRpcIdentifier(rpcSpecifierForMethodOnMethod, httpMethod)
 									if (!rpcAllowedForMethodOnMethod) {

--- a/libs/rpc/src/server.ts
+++ b/libs/rpc/src/server.ts
@@ -29,6 +29,7 @@ import type {
 	PrimServerSocketAnswerRpc,
 } from "./interfaces"
 import { extractPromiseData } from "./extract/promises"
+import { checkRpcIdentifier, getFunctionRpcProperty } from "./allow"
 
 /**
  *
@@ -69,266 +70,255 @@ function createServerActions(
 ): PrimServerActionsBase {
 	const { jsonHandler, prefix: serverPrefix, handleError, handleBlobs } = serverOptions
 	const binaryHandlingNeeded = handleBlobs || !jsonHandler?.binary
-	const prepareCall = (given: CommonServerSimpleGivenOptions = {}): RpcCall | RpcCall[] => {
-		try {
-			const givenReq = checkHttpLikeRequest(given, jsonHandler?.binary)
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-			const { body, method, url: possibleUrl, blobs } = givenReq
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-			const providedBody = method === "POST" && body
-			if (providedBody) {
-				const prepared = jsonHandler.parse(givenReq.body) as RpcCall | RpcCall[]
-				const possibleCalls = Array.isArray(prepared) ? checkRpcCall(prepared) : [checkRpcCall(prepared)]
-				if (binaryHandlingNeeded && Object.entries(blobs || {}).length > 0) {
-					for (const toCall of possibleCalls) {
-						toCall.args = toCall.args.map(arg => mergeBlobData(arg, blobs))
+	return {
+		prepareCall(given = {}) {
+			try {
+				const givenReq = checkHttpLikeRequest(given, jsonHandler?.binary)
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				const { body, method, url: possibleUrl, blobs } = givenReq
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				const providedBody = method === "POST" && body
+				if (providedBody) {
+					const prepared = jsonHandler.parse(givenReq.body) as RpcCall | RpcCall[]
+					const possibleCalls = Array.isArray(prepared) ? checkRpcCall(prepared) : [checkRpcCall(prepared)]
+					if (binaryHandlingNeeded && Object.entries(blobs || {}).length > 0) {
+						for (const toCall of possibleCalls) {
+							toCall.args = toCall.args.map(arg => mergeBlobData(arg, blobs))
+						}
 					}
+					return Array.isArray(prepared) ? possibleCalls : possibleCalls[0]
 				}
-				return Array.isArray(prepared) ? possibleCalls : possibleCalls[0]
-			}
-			const providedUrl = method === "GET" && possibleUrl
-			if (providedUrl) {
-				const positional = []
-				const { query, url } = queryString.parseUrl(possibleUrl, {
-					arrayFormat: "comma",
-					parseBooleans: true,
-					parseNumbers: true,
-				})
-				const id: string | number = "-" in query && !Array.isArray(query["-"]) ? query["-"] : undefined
-				delete query["-"]
-				const entries = Object.entries(query)
-				// determine if positional arguments were given (must start at 0, none can be missing)
-				for (const [possibleIndex, value] of entries) {
-					const index = Number.parseInt(possibleIndex, 10)
-					if (Number.isNaN(index)) {
-						break
+				const providedUrl = method === "GET" && possibleUrl
+				if (providedUrl) {
+					const positional = []
+					const { query, url } = queryString.parseUrl(possibleUrl, {
+						arrayFormat: "comma",
+						parseBooleans: true,
+						parseNumbers: true,
+					})
+					const id: string | number = "-" in query && !Array.isArray(query["-"]) ? query["-"] : undefined
+					delete query["-"]
+					const entries = Object.entries(query)
+					// determine if positional arguments were given (must start at 0, none can be missing)
+					for (const [possibleIndex, value] of entries) {
+						const index = Number.parseInt(possibleIndex, 10)
+						if (Number.isNaN(index)) {
+							break
+						}
+						const nextIndex = index === 0 || typeof positional[index - 1] !== "undefined"
+						if (!nextIndex) {
+							break
+						}
+						positional[index] = value
 					}
-					const nextIndex = index === 0 || typeof positional[index - 1] !== "undefined"
-					if (!nextIndex) {
-						break
-					}
-					positional[index] = value
+					const args =
+						positional.length > 0 && positional.length === entries.length
+							? positional
+							: entries.length === 0
+								? []
+								: query
+					let method = url.replace(RegExp("^" + serverPrefix + "\\/?"), "")
+					method = method !== "" ? method : "default"
+					return checkRpcCall({ id, method, args })
 				}
-				const args =
-					positional.length > 0 && positional.length === entries.length ? positional : entries.length === 0 ? [] : query
-				let method = url.replace(RegExp("^" + serverPrefix + "\\/?"), "")
-				method = method !== "" ? method : "default"
-				return checkRpcCall({ id, method, args })
-			}
-			throw { error: "Response can not be generated from request" }
-		} catch (error) {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-			if (typeof error === "object" && "primRpc" in error && error.primRpc === PrimRpcSpecific) {
-				// FIXME: errors aren't expected to be thrown here but is needed for next step
-				// use same pattern from Prim RPC client to handle special objects
-				const internalError: RpcCall = { method: "_error_", args: error }
-				return internalError
-			}
-			// RPC call is purposefully invalid to trigger invalid RPC error in next step
-			return { method: "" }
-		}
-	}
-	const prepareRpc = async (
-		calls: RpcCall | RpcCall[],
-		context?: unknown,
-		cbResults?: (a: RpcAnswer) => void
-	): Promise<RpcAnswer | RpcAnswer[]> => {
-		// FIXME: checkRpcCall is called twice (once in prepareCall and once here) and this could be optimized
-		// NOTE: new Prim client should be created on each request so callback results are not shared
-		try {
-			const { client, socketEvent: event, configured } = instance ?? createPrimInstance(serverOptions)
-			const callList = Array.isArray(calls) ? calls : [calls]
-			const answeringCalls = callList.map(async (givenUnchecked): Promise<RpcAnswer> => {
-				const { method, args /* : argsGiven */, id } = checkRpcCall(givenUnchecked)
-				// const args = Object.entries(blobs || {}).length > 0 ? argsGiven.map(arg => mergeBlobLikeWithGiven(arg, blobs)) : argsGiven
-				if (method === "_error_") {
-					throw args[0] // from internal prepareCall step
+				throw { error: "Response can not be generated from request" }
+			} catch (error) {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+				if (typeof error === "object" && "primRpc" in error && error.primRpc === PrimRpcSpecific) {
+					// FIXME: errors aren't expected to be thrown here but is needed for next step
+					// use same pattern from Prim RPC client to handle special objects
+					const internalError: RpcCall = { method: "_error_", args: error }
+					return internalError
 				}
-				const rpcVersion: Partial<RpcAnswer> = useVersionInRpc ? { prim: primMajorVersion } : {}
-				const rpcBase: Partial<RpcAnswer> = { ...rpcVersion, id }
-				try {
-					const methodExpanded = method.split("/")
-					// using `configured.module` if module was provided directly to server
-					// and resolve given module first if it was dynamically imported
-					const givenModulePromise = (
-						typeof configured.module === "function" ? configured.module() : configured.module
-					) as PrimServerOptions["module"] | Promise<PrimServerOptions["module"]>
-					const givenModule = givenModulePromise instanceof Promise ? await givenModulePromise : givenModulePromise
-					const targetLocal = getProperty(givenModule, methodExpanded) as AnyFunction & { rpc?: boolean }
-					let possiblyMethodOnMethod = false
-					if (givenModule) {
-						// While subsequent checks cover these situations, some key props will immediately invalidate a given method
-						if (denyList.filter(given => methodExpanded.includes(given)).length > 0) {
-							return { ...rpcBase, error: "Method was not valid" }
-						}
-						// these checks only apply if module is provided directly (determined on actual server with module)
-						if (methodExpanded.length > 1) {
-							const currentPathCheck: string[] = []
-							// NOTE: `.methodsOnMethods` is only allowed if method is defined _directly_ on another method
-							const previousPathsIncludeFunction = methodExpanded
-								.slice(0, serverOptions.methodsOnMethods.length > 0 ? -2 : -1)
-								.map(method => {
-									currentPathCheck.push(method)
-									const currentPath = getProperty(givenModule, currentPathCheck) as unknown
-									return typeof currentPath !== "object" // paths cannot contain "function" type any other type
-								})
-								.reduce((a, b) => a || b, false)
-							if (previousPathsIncludeFunction) {
-								return { ...rpcBase, error: "Method on method was not valid" }
-							}
-							const directPreviousPath = getProperty(givenModule, methodExpanded.slice(0, -1)) as unknown
-							const disallowedMethodOnMethod =
-								typeof directPreviousPath === "function" &&
-								!serverOptions.methodsOnMethods.includes(methodExpanded.slice(-1)[0])
-							if (disallowedMethodOnMethod) {
-								return { ...rpcBase, error: "Method on method was not allowed" }
-							}
-							possiblyMethodOnMethod =
-								typeof directPreviousPath === "function" &&
-								"rpc" in directPreviousPath &&
-								typeof directPreviousPath.rpc === "boolean" &&
-								directPreviousPath.rpc
-						}
-						if (typeof targetLocal === "undefined" || targetLocal === null) {
-							return { ...rpcBase, error: "Method was not found" }
-						}
-						if (typeof targetLocal !== "function") {
-							return { ...rpcBase, error: "Method was not callable" }
-						}
-						const methodAllowedDirectly =
-							"rpc" in targetLocal && typeof targetLocal.rpc === "boolean" && targetLocal.rpc
-						if (!methodAllowedDirectly) {
-							const allowedInSchema =
-								Object.entries(serverOptions.allowList ?? {}).length > 0 &&
-								!!getProperty(serverOptions.allowList, methodExpanded)
-							if (!allowedInSchema && !possiblyMethodOnMethod) {
-								return { ...rpcBase, error: "Method was not allowed" }
-							}
-						}
+				// RPC call is purposefully invalid to trigger invalid RPC error in next step
+				return { method: "" }
+			}
+		},
+		async prepareRpc(calls, context, httpMethod) {
+			// FIXME: checkRpcCall is called twice (once in prepareCall and once here) and this could be optimized
+			// NOTE: new Prim client should be created on each request so callback results are not shared
+			try {
+				const { client, socketEvent: event, configured } = instance ?? createPrimInstance(serverOptions)
+				const callList = Array.isArray(calls) ? calls : [calls]
+				const answeringCalls = callList.map(async (givenUnchecked): Promise<RpcAnswer> => {
+					const { method, args /* : argsGiven */, id } = checkRpcCall(givenUnchecked)
+					// const args = Object.entries(blobs || {}).length > 0 ? argsGiven.map(arg => mergeBlobLikeWithGiven(arg, blobs)) : argsGiven
+					if (method === "_error_") {
+						throw args[0] // from internal prepareCall step
 					}
-					// NOTE: use `targetRemote` below even if target is local to allow callbacks to be used with server
-					// (server and client share event handlers on `.internal` option that allows for usage of callbacks)
-					if (givenModule && targetLocal) {
-						// The module was provided and the target exists. Checks have already run and did not return an error
-						// so we can call the method using the client.
-						if (cbResults) {
-							event.on("response", cbResults)
-						}
-						// call module with `client` if not provided directly to server (checks already ran on module, if provided)
-						const targetRemote = getProperty(client, methodExpanded) as AnyFunction & { rpc?: boolean }
-						const processedArgs = configured.preCall?.(args, targetLocal) ?? args
-						const result = (await Reflect.apply(targetRemote, context, processedArgs)) as unknown
-						const [resultExtracted, promisesRecord] = extractPromiseData(
-							result,
-							serverOptions?.flags?.supportMultiplePromiseResults
-						)
-						Object.entries(promisesRecord).forEach(async ([id, promise]) => {
-							try {
-								const result = await promise
-								if (cbResults) cbResults({ id, result })
-								event.emit("response", { id, result })
-							} catch (e) {
-								if (handleError && e instanceof Error) {
-									const error = serializeError<unknown>(e)
-									if (!serverOptions.showErrorStack) {
-										delete error.stack
-									}
-									return { id, error }
+					const rpcVersion: Partial<RpcAnswer> = useVersionInRpc ? { prim: primMajorVersion } : {}
+					const rpcBase: Partial<RpcAnswer> = { ...rpcVersion, id }
+					try {
+						const methodExpanded = method.split("/")
+						// using `configured.module` if module was provided directly to server
+						// and resolve given module first if it was dynamically imported
+						const givenModulePromise = (
+							typeof configured.module === "function" ? configured.module() : configured.module
+						) as PrimServerOptions["module"] | Promise<PrimServerOptions["module"]>
+						const givenModule = givenModulePromise instanceof Promise ? await givenModulePromise : givenModulePromise
+						const targetLocal = getProperty(givenModule, methodExpanded) as AnyFunction & { rpc?: boolean }
+						let possiblyMethodOnMethod = false
+						if (givenModule) {
+							// While subsequent checks cover these situations, some key props will immediately invalidate a given method
+							if (denyList.filter(given => methodExpanded.includes(given)).length > 0) {
+								return { ...rpcBase, error: "Method was not valid" }
+							}
+							// these checks only apply if module is provided directly (determined on actual server with module)
+							if (methodExpanded.length > 1) {
+								const currentPathCheck: string[] = []
+								// NOTE: `.methodsOnMethods` is only allowed if method is defined _directly_ on another method
+								const previousPathsIncludeFunction = methodExpanded
+									.slice(0, serverOptions.methodsOnMethods.length > 0 ? -2 : -1)
+									.map(method => {
+										currentPathCheck.push(method)
+										const currentPath = getProperty(givenModule, currentPathCheck) as unknown
+										return typeof currentPath !== "object" // paths cannot contain "function" type any other type
+									})
+									.reduce((a, b) => a || b, false)
+								if (previousPathsIncludeFunction) {
+									return { ...rpcBase, error: "Method on method was not valid" }
 								}
-								// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-								if (cbResults) cbResults({ id, error: e })
-								event.emit("response", { id, error: e })
+								const directPreviousPath = getProperty(givenModule, methodExpanded.slice(0, -1)) as unknown
+								const disallowedMethodOnMethod =
+									typeof directPreviousPath === "function" &&
+									!serverOptions.methodsOnMethods.includes(methodExpanded.slice(-1)[0])
+								if (disallowedMethodOnMethod) {
+									return { ...rpcBase, error: "Method on method was not allowed" }
+								}
+								const rpcProperty = getFunctionRpcProperty(directPreviousPath)
+								possiblyMethodOnMethod = checkRpcIdentifier(rpcProperty, httpMethod)
 							}
-						})
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-						const processedResult = configured.postCall?.(resultExtracted, targetLocal) ?? resultExtracted
-						return { ...rpcBase, result: processedResult }
-					} else {
-						// If either the module wasn't provided or target doesn't exist (even if module does), send a request using
-						// a client that doesn't know about the module provided (will use provided plugin to server).
-						const { module: _moduleProvided, ...limitedOptions } = serverOptions
-						// create client that doesn't have access to module (target may not exist but other targets might)
-						const { client: limitedClient, socketEvent: limitedEvent } = createPrimInstance(limitedOptions)
-						if (cbResults) {
-							limitedEvent.on("response", cbResults)
+							if (typeof targetLocal === "undefined" || targetLocal === null) {
+								return { ...rpcBase, error: "Method was not found" }
+							}
+							if (typeof targetLocal !== "function") {
+								return { ...rpcBase, error: "Method was not callable" }
+							}
+							const rpcProperty = getFunctionRpcProperty(targetLocal)
+							const methodAllowedDirectly = checkRpcIdentifier(rpcProperty, httpMethod)
+							if (!methodAllowedDirectly) {
+								const allowedInSchema =
+									Object.entries(serverOptions.allowList ?? {}).length > 0 &&
+									!!getProperty(serverOptions.allowList, methodExpanded)
+								if (!allowedInSchema && !possiblyMethodOnMethod) {
+									return { ...rpcBase, error: "Method was not allowed" }
+								}
+							}
 						}
-						const targetRemote = getProperty(limitedClient, methodExpanded) as AnyFunction & { rpc?: boolean }
-						// const targetLocal = getProperty(givenModule, methodExpanded) as AnyFunction & { rpc?: boolean }
-						// const processedArgs = preprocess(...args).bind(targetLocal)
-						const processedArgs = configured.preCall?.(args) ?? args
-						const result = (await Reflect.apply(targetRemote, context, processedArgs)) as unknown
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-						const processedResult = configured.postCall?.(result) ?? result
-						return { ...rpcBase, result: processedResult }
-					}
-					// TODO: today, result must be supported by JSON handler but consider supporting returned functions
-					// in the same way that callback are supported today (by passing reference to client)
-				} catch (e) {
-					// JSON.stringify on Error results in an empty object. Since Error is common, serialize it
-					// when a custom JSON handler is not provided
-					if (handleError && e instanceof Error) {
-						const error = serializeError<unknown>(e)
-						if (!serverOptions.showErrorStack) {
-							delete error.stack
+						// NOTE: use `targetRemote` below even if target is local to allow callbacks to be used with server
+						// (server and client share event handlers on `.internal` option that allows for usage of callbacks)
+						if (givenModule && targetLocal) {
+							// The module was provided and the target exists. Checks have already run and did not return an error
+							// so we can call the method using the client.
+							// call module with `client` if not provided directly to server (checks already ran on module, if provided)
+							const targetRemote = getProperty(client, methodExpanded) as AnyFunction & { rpc?: boolean }
+							const processedArgs = configured.preCall?.(args, targetLocal) ?? args
+							const result = (await Reflect.apply(targetRemote, context, processedArgs)) as unknown
+							const [resultExtracted, promisesRecord] = extractPromiseData(
+								result,
+								serverOptions?.flags?.supportMultiplePromiseResults
+							)
+							Object.entries(promisesRecord).forEach(async ([id, promise]) => {
+								try {
+									const result = await promise
+									event.emit("response", { id, result })
+								} catch (e) {
+									if (handleError && e instanceof Error) {
+										const error = serializeError<unknown>(e)
+										if (!serverOptions.showErrorStack) {
+											delete error.stack
+										}
+										return { id, error }
+									}
+									event.emit("response", { id, error: e })
+								}
+							})
+							// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+							const processedResult = configured.postCall?.(resultExtracted, targetLocal) ?? resultExtracted
+							return { ...rpcBase, result: processedResult }
+						} else {
+							// If either the module wasn't provided or target doesn't exist (even if module does), send a request using
+							// a client that doesn't know about the module provided (will use provided plugin to server).
+							const { module: _moduleProvided, ...limitedOptions } = serverOptions
+							// create client that doesn't have access to module (target may not exist but other targets might)
+							const { client: limitedClient } = createPrimInstance(limitedOptions)
+							const targetRemote = getProperty(limitedClient, methodExpanded) as AnyFunction & { rpc?: boolean }
+							// const targetLocal = getProperty(givenModule, methodExpanded) as AnyFunction & { rpc?: boolean }
+							// const processedArgs = preprocess(...args).bind(targetLocal)
+							const processedArgs = configured.preCall?.(args) ?? args
+							const result = (await Reflect.apply(targetRemote, context, processedArgs)) as unknown
+							// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+							const processedResult = configured.postCall?.(result) ?? result
+							return { ...rpcBase, result: processedResult }
 						}
-						return { ...rpcBase, error }
+						// TODO: today, result must be supported by JSON handler but consider supporting returned functions
+						// in the same way that callback are supported today (by passing reference to client)
+					} catch (e) {
+						// JSON.stringify on Error results in an empty object. Since Error is common, serialize it
+						// when a custom JSON handler is not provided
+						if (handleError && e instanceof Error) {
+							const error = serializeError<unknown>(e)
+							if (!serverOptions.showErrorStack) {
+								delete error.stack
+							}
+							return { ...rpcBase, error }
+						}
+						return { ...rpcBase, error: e }
 					}
-					return { ...rpcBase, error: e }
-				}
-			})
-			const answeredCalls = checkRpcResult(await Promise.all(answeringCalls))
-			return answeredCalls.length === 1 ? answeredCalls[0] : answeredCalls
-		} catch (error: unknown) {
-			if (typeof error === "object" && error !== null && "primRpc" in error && error.primRpc === PrimRpcSpecific) {
-				return error as RpcAnswer | RpcAnswer[]
-			}
-			return { error: "Unknown RPC error" }
-		}
-	}
-	const prepareSend = (given: RpcAnswer | RpcAnswer[]): CommonServerResponseOptions => {
-		let blobs: BlobRecords = {}
-		const givenOnly = (separationNeeded => {
-			if (separationNeeded) {
-				const givenSeparated = Array.isArray(given) ? given.map(g => extractBlobData(g)) : [extractBlobData(given)]
-				const givenOnly = givenSeparated.map(([given, newBlobs]) => {
-					blobs = { ...blobs, ...newBlobs }
-					return given
 				})
-				return givenOnly
-			} else {
-				return [given]
+				const answeredCalls = checkRpcResult(await Promise.all(answeringCalls))
+				return answeredCalls.length === 1 ? answeredCalls[0] : answeredCalls
+			} catch (error: unknown) {
+				if (typeof error === "object" && error !== null && "primRpc" in error && error.primRpc === PrimRpcSpecific) {
+					return error as RpcAnswer | RpcAnswer[]
+				}
+				return { error: "Unknown RPC error" }
 			}
-		})(binaryHandlingNeeded)
-		const body = jsonHandler.stringify(Array.isArray(given) ? givenOnly : givenOnly[0]) as string
-		// NOTE: body length is generally handled by server framework, I think
-		const blobCount = Object.keys(blobs).length
-		// these mime types are just base suggestions to be overridden by chosen plugin, if applicable
-		const singleFileResult =
-			blobCount === 1 && !Array.isArray(given) && typeof given.result === "string" && given.result.startsWith("_bin_")
-		let contentType = singleFileResult
-			? "application/octet-stream"
-			: blobCount > 1
-				? "multipart/form-data"
-				: jsonHandler.mediaType ?? "application/json"
-		contentType = jsonHandler?.binary ? "application/octet-stream" : contentType
-		const headers = { "content-type": contentType }
-		const answers = Array.isArray(given) ? given : [given]
-		const statuses = answers.map(answer => ("error" in answer ? 500 : "result" in answer ? 200 : 400))
-		const notOkay = statuses.filter(stat => stat !== 200)
-		const errored = statuses.filter(stat => stat === 500)
-		// NOTE: return 200:okay, 400:missing, 500:error if any call has that status
-		const status = notOkay.length > 0 ? (errored.length > 0 ? 500 : 400) : 200
-		try {
-			return checkHttpLikeResponse({ body, headers, status, blobs }, jsonHandler?.binary)
-		} catch (error: unknown) {
-			if (typeof error === "object" && error !== null && "primRpc" in error && error.primRpc === PrimRpcSpecific) {
-				return { body: jsonHandler.stringify(error) as string, headers: {}, status: 500 }
+		},
+		prepareSend(given) {
+			let blobs: BlobRecords = {}
+			const givenOnly = (separationNeeded => {
+				if (separationNeeded) {
+					const givenSeparated = Array.isArray(given) ? given.map(g => extractBlobData(g)) : [extractBlobData(given)]
+					const givenOnly = givenSeparated.map(([given, newBlobs]) => {
+						blobs = { ...blobs, ...newBlobs }
+						return given
+					})
+					return givenOnly
+				} else {
+					return [given]
+				}
+			})(binaryHandlingNeeded)
+			const body = jsonHandler.stringify(Array.isArray(given) ? givenOnly : givenOnly[0]) as string
+			// NOTE: body length is generally handled by server framework, I think
+			const blobCount = Object.keys(blobs).length
+			// these mime types are just base suggestions to be overridden by chosen plugin, if applicable
+			const singleFileResult =
+				blobCount === 1 && !Array.isArray(given) && typeof given.result === "string" && given.result.startsWith("_bin_")
+			let contentType = singleFileResult
+				? "application/octet-stream"
+				: blobCount > 1
+					? "multipart/form-data"
+					: jsonHandler.mediaType ?? "application/json"
+			contentType = jsonHandler?.binary ? "application/octet-stream" : contentType
+			const headers = { "content-type": contentType }
+			const answers = Array.isArray(given) ? given : [given]
+			const statuses = answers.map(answer => ("error" in answer ? 500 : "result" in answer ? 200 : 400))
+			const notOkay = statuses.filter(stat => stat !== 200)
+			const errored = statuses.filter(stat => stat === 500)
+			// NOTE: return 200:okay, 400:missing, 500:error if any call has that status
+			const status = notOkay.length > 0 ? (errored.length > 0 ? 500 : 400) : 200
+			try {
+				return checkHttpLikeResponse({ body, headers, status, blobs }, jsonHandler?.binary)
+			} catch (error: unknown) {
+				if (typeof error === "object" && error !== null && "primRpc" in error && error.primRpc === PrimRpcSpecific) {
+					return { body: jsonHandler.stringify(error) as string, headers: {}, status: 500 }
+				}
+				const fallbackError = { error: "Unknown RPC error during send" }
+				return { body: jsonHandler.stringify(fallbackError) as string, headers: {}, status: 500 }
 			}
-			const fallbackError = { error: "Unknown RPC error during send" }
-			return { body: jsonHandler.stringify(fallbackError) as string, headers: {}, status: 500 }
-		}
+		},
 	}
-	return { prepareCall, prepareRpc, prepareSend }
 }
 
 function createServerEvents(serverOptions: PrimServerOptions): PrimServerEvents {
@@ -340,7 +330,14 @@ function createServerEvents(serverOptions: PrimServerOptions): PrimServerEvents 
 			context?: unknown
 		): Promise<CommonServerResponseOptions> => {
 			const preparedArgs = prepareCall(given)
-			const result = await prepareRpc(preparedArgs, context)
+			let httpMethod: string | null // don't use `false` as a default value, used by `checkDirectFunctionRpcProperty()`
+			try {
+				const { method } = checkHttpLikeRequest(given, serverOptions.jsonHandler?.binary)
+				httpMethod = method
+			} catch (error) {
+				httpMethod = null
+			}
+			const result = await prepareRpc(preparedArgs, context, httpMethod)
 			const preparedResult = prepareSend(result)
 			return preparedResult
 		}
@@ -372,7 +369,7 @@ function createSocketEvents(serverOptions: PrimServerOptions): PrimServerSocketE
 				send(body)
 			})
 			const preparedArgs = prepareCall({ body })
-			const result = await prepareRpcBase(preparedArgs, context)
+			const result = await prepareRpcBase(preparedArgs, context, false)
 			const preparedResult = prepareSend(result)
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 			send(preparedResult.body)
@@ -384,7 +381,7 @@ function createSocketEvents(serverOptions: PrimServerOptions): PrimServerSocketE
 			event.on("response", data => {
 				send(data)
 			})
-			const result = await prepareRpcBase(body, context)
+			const result = await prepareRpcBase(body, context, false)
 			send(result)
 		}
 		// TODO: return `prepare...()` functions below, in event that something more than `call()` is needed


### PR DESCRIPTION
This adds a new feature and restricts Prim+RPC usage depending on the request made. All RPC requests must now be made over POST by default when sent over a network (inapplicable to IPC) and GET requests are now disabled by default.

- POST requests are now the only method allowed by default (GET requests must be enabled with new keyword)
- Added keyword `"idempotent"` for:
  - `.rpc` property value of functions
  - Function key value given in `options.allowList`
  - Value of key in in `options.methodsOnMethods`
- `.methodsOnMethods` is no longer an array: it is an object with keys representing the names of functions, values being either true (it is RPC) or "idempotent" (RPC utilizing new keyword)
- Updated documentation to reflect new usage and updated code examples
- Added tests to ensure this behavior works as expected